### PR TITLE
Fix circular references and add db context interface

### DIFF
--- a/FileManager.Application/FileManager.Application.csproj
+++ b/FileManager.Application/FileManager.Application.csproj
@@ -15,8 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FileManager.Domain\FileManager.Domain.csproj" />
-	<ProjectReference Include="..\FileManager.Infrastructure\FileManager.Infrastructure.csproj" />
-
   </ItemGroup>
 
 </Project>

--- a/FileManager.Application/Interfaces/IAppDbContext.cs
+++ b/FileManager.Application/Interfaces/IAppDbContext.cs
@@ -1,0 +1,21 @@
+using FileManager.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FileManager.Application.Interfaces;
+
+public interface IAppDbContext
+{
+    DbSet<User> Users { get; }
+    DbSet<Group> Groups { get; }
+    DbSet<Folder> Folders { get; }
+    DbSet<Files> Files { get; }
+    DbSet<FileVersion> FileVersions { get; }
+    DbSet<AccessRule> AccessRules { get; }
+    DbSet<AuditLog> AuditLogs { get; }
+    DbSet<Notification> Notifications { get; }
+    DbSet<FileEditSession> FileEditSessions { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/FileManager.Application/Services/FileMonitoringService.cs
+++ b/FileManager.Application/Services/FileMonitoringService.cs
@@ -1,6 +1,5 @@
 ﻿using FileManager.Application.Interfaces;
 using FileManager.Domain.Interfaces;
-using FileManager.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -49,7 +48,7 @@ public class FileMonitoringService : BackgroundService
         var filesRepository = scope.ServiceProvider.GetRequiredService<IFilesRepository>();
         var yandexDiskService = scope.ServiceProvider.GetRequiredService<IYandexDiskService>();
         var fileVersionService = scope.ServiceProvider.GetRequiredService<IFileVersionService>();
-        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var context = scope.ServiceProvider.GetRequiredService<IAppDbContext>();
 
         // Получаем все активные сессии редактирования
         var activeSessions = await context.FileEditSessions

--- a/FileManager.Application/Services/FilePreviewService.cs
+++ b/FileManager.Application/Services/FilePreviewService.cs
@@ -3,7 +3,6 @@ using FileManager.Application.Interfaces;
 using FileManager.Domain.Entities;
 using FileManager.Domain.Enums;
 using FileManager.Domain.Interfaces;
-using FileManager.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System;
@@ -16,7 +15,7 @@ public class FilePreviewService : IFilePreviewService
     private readonly IYandexDiskService _yandexDiskService;
     private readonly IAuditService _auditService;
     private readonly IFileVersionService _fileVersionService;
-    private readonly AppDbContext _context;
+    private readonly IAppDbContext _context;
     private readonly ILogger<FilePreviewService> _logger;
 
     private readonly string[] _previewableExtensions = { ".pdf", ".jpg", ".jpeg", ".png", ".gif", ".txt", ".docx", ".xlsx", ".pptx" };
@@ -27,7 +26,7 @@ public class FilePreviewService : IFilePreviewService
         IYandexDiskService yandexDiskService,
         IAuditService auditService,
         IFileVersionService fileVersionService,
-        AppDbContext context,
+        IAppDbContext context,
         ILogger<FilePreviewService> logger)
     {
         _filesRepository = filesRepository;

--- a/FileManager.Application/Services/FileVersionService.cs
+++ b/FileManager.Application/Services/FileVersionService.cs
@@ -3,18 +3,16 @@ using FileManager.Application.Interfaces;
 using FileManager.Domain.Entities;
 using FileManager.Domain.Enums;
 using FileManager.Domain.Interfaces;
-using FileManager.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using FileManager.Infrastructure.Configuration;
 using System;
 
 namespace FileManager.Application.Services;
 
 public class FileVersionService : IFileVersionService
 {
-    private readonly AppDbContext _context;
+    private readonly IAppDbContext _context;
     private readonly IFilesRepository _filesRepository;
     private readonly IYandexDiskService _yandexDiskService;
     private readonly IAuditService _auditService;
@@ -22,7 +20,7 @@ public class FileVersionService : IFileVersionService
     private readonly ILogger<FileVersionService> _logger;
 
     public FileVersionService(
-        AppDbContext context,
+        IAppDbContext context,
         IFilesRepository filesRepository,
         IYandexDiskService yandexDiskService,
         IAuditService auditService,

--- a/FileManager.Infrastructure/Data/AppDbContext.cs
+++ b/FileManager.Infrastructure/Data/AppDbContext.cs
@@ -1,9 +1,10 @@
 ﻿using FileManager.Domain.Entities;
+using FileManager.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace FileManager.Infrastructure.Data;
 
-public class AppDbContext : DbContext
+public class AppDbContext : DbContext, IAppDbContext
 {
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
     {

--- a/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
+++ b/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceExtensions
         // База данных
         services.AddDbContext<AppDbContext>(options =>
             options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
+        services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
 
         // Настройки конфигурации
         services.Configure<YandexDiskOptions>(configuration.GetSection(YandexDiskOptions.SectionName));


### PR DESCRIPTION
## Summary
- decouple FileManager.Application from infrastructure layer
- introduce `IAppDbContext` abstraction
- update services to rely on the new interface
- register `IAppDbContext` in DI

## Testing
- `dotnet build FileManager.Web.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688cb230ea608330aceda94c390fd0d4