### PR TITLE
Добавить регистрацию пользователей

### DIFF
--- a/FileManager.Application/DTOs/GroupDetailsDto.cs
+++ b/FileManager.Application/DTOs/GroupDetailsDto.cs
@@ -1,0 +1,7 @@
+using System;
+using System.Collections.Generic;
+
+namespace FileManager.Application.DTOs;
+
+public record GroupDetailsDto(Guid Id, string Name, List<UserDto> Users);
+

--- a/FileManager.Infrastructure/Data/DatabaseInitializer.cs
+++ b/FileManager.Infrastructure/Data/DatabaseInitializer.cs
@@ -1,15 +1,11 @@
 using FileManager.Application.Services;
-using FileManager.Domain.Entities;
-using FileManager.Domain.Enums;
-using FileManager.Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using System.IO;
 
 namespace FileManager.Infrastructure.Data;
 
 public static class DatabaseInitializer
 {
-    public static async Task InitializeAsync(AppDbContext context, UserService userService, IYandexDiskService yandexDiskService)
+    public static async Task InitializeAsync(AppDbContext context, UserService userService)
     {
         // Проверяем, есть ли пользователи
         if (await context.Users.AnyAsync())
@@ -26,19 +22,6 @@ public static class DatabaseInitializer
                 isAdmin: true
             );
 
-            // Создаем корневую папку без тестовых данных
-            var rootFolder = new Folder
-            {
-                Name = "Корневая папка",
-                YandexPath = "/FileManager",
-                CreatedById = admin.Id
-            };
-
-            context.Folders.Add(rootFolder);
-            await context.SaveChangesAsync();
-
-            await SyncDiskAsync(context, admin, rootFolder, yandexDiskService);
-
             Console.WriteLine("=== База данных инициализирована ===");
             Console.WriteLine("Администратор:");
             Console.WriteLine("  Email: admin@filemanager.com");
@@ -54,63 +37,4 @@ public static class DatabaseInitializer
         }
     }
 
-    private static async Task SyncDiskAsync(AppDbContext context, User admin, Folder root, IYandexDiskService yandexDiskService)
-    {
-        async Task Traverse(string path, Folder parent)
-        {
-            var items = await yandexDiskService.GetFolderContentsAsync(path);
-
-            foreach (var item in items)
-            {
-                if (item.IsDirectory)
-                {
-                    var folder = new Folder
-                    {
-                        Name = item.Name,
-                        YandexPath = item.Path,
-                        ParentFolderId = parent.Id,
-                        CreatedById = admin.Id
-                    };
-
-                    context.Folders.Add(folder);
-                    await context.SaveChangesAsync();
-
-                    await Traverse(item.Path, folder);
-                }
-                else
-                {
-                    var extension = Path.GetExtension(item.Name).ToLowerInvariant();
-                    var file = new Files
-                    {
-                        Name = Path.GetFileNameWithoutExtension(item.Name),
-                        OriginalName = item.Name,
-                        Extension = extension,
-                        YandexPath = item.Path,
-                        FileType = DetermineFileType(extension),
-                        SizeBytes = item.Size,
-                        FolderId = parent.Id,
-                        UploadedById = admin.Id
-                    };
-
-                    context.Files.Add(file);
-                }
-            }
-
-            await context.SaveChangesAsync();
-        }
-
-        await Traverse(root.YandexPath, root);
-    }
-
-    private static FileType DetermineFileType(string extension) => extension switch
-    {
-        ".doc" or ".docx" => FileType.Document,
-        ".xls" or ".xlsx" => FileType.Spreadsheet,
-        ".ppt" or ".pptx" => FileType.Presentation,
-        ".pdf" => FileType.Pdf,
-        ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" => FileType.Image,
-        ".txt" => FileType.Text,
-        ".zip" or ".rar" or ".7z" => FileType.Archive,
-        _ => FileType.Other
-    };
 }

--- a/FileManager.Web/Controllers/GroupsApiController.cs
+++ b/FileManager.Web/Controllers/GroupsApiController.cs
@@ -1,5 +1,7 @@
 using FileManager.Application.DTOs;
 using FileManager.Application.Interfaces;
+using FileManager.Domain.Entities;
+using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -26,4 +28,87 @@ public class GroupsApiController : ControllerBase
             .ToListAsync();
         return Ok(groups);
     }
+
+    [HttpGet("{id}")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<ActionResult<GroupDetailsDto>> GetById(Guid id)
+    {
+        var group = await _context.Groups
+            .Include(g => g.Users)
+            .FirstOrDefaultAsync(g => g.Id == id);
+        if (group == null)
+            return NotFound();
+
+        var dto = new GroupDetailsDto(
+            group.Id,
+            group.Name,
+            group.Users.Select(u => new UserDto
+            {
+                Id = u.Id,
+                Email = u.Email,
+                FullName = u.FullName,
+                Department = u.Department,
+                IsAdmin = u.IsAdmin
+            }).ToList());
+        return Ok(dto);
+    }
+
+    [HttpPost]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<ActionResult<GroupDto>> Create([FromBody] CreateGroupRequest request)
+    {
+        var group = new Group { Name = request.Name, Description = request.Description };
+        _context.Groups.Add(group);
+        await _context.SaveChangesAsync();
+        return Ok(new GroupDto(group.Id, group.Name));
+    }
+
+    [HttpPost("{groupId}/users/{userId}")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<IActionResult> AddUser(Guid groupId, Guid userId)
+    {
+        var group = await _context.Groups.Include(g => g.Users).FirstOrDefaultAsync(g => g.Id == groupId);
+        var user = await _context.Users.FindAsync(userId);
+        if (group == null || user == null)
+            return NotFound();
+
+        if (!group.Users.Any(u => u.Id == userId))
+        {
+            group.Users.Add(user);
+            await _context.SaveChangesAsync();
+        }
+        return NoContent();
+    }
+
+    [HttpDelete("{groupId}/users/{userId}")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<IActionResult> RemoveUser(Guid groupId, Guid userId)
+    {
+        var group = await _context.Groups.Include(g => g.Users).FirstOrDefaultAsync(g => g.Id == groupId);
+        if (group == null)
+            return NotFound();
+
+        var user = group.Users.FirstOrDefault(u => u.Id == userId);
+        if (user == null)
+            return NotFound();
+
+        group.Users.Remove(user);
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var group = await _context.Groups.FindAsync(id);
+        if (group == null)
+            return NotFound();
+
+        _context.Groups.Remove(group);
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    public record CreateGroupRequest(string Name, string? Description);
 }

--- a/FileManager.Web/Controllers/UsersApiController.cs
+++ b/FileManager.Web/Controllers/UsersApiController.cs
@@ -1,5 +1,6 @@
 using FileManager.Application.DTOs;
 using FileManager.Application.Interfaces;
+using FileManager.Application.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,17 +11,39 @@ namespace FileManager.Web.Controllers;
 [Route("api/users")]
 public class UsersApiController : ControllerBase
 {
-    private readonly IUserService _userService;
+    private readonly IUserService _userDtoService;
+    private readonly UserService _userService;
 
-    public UsersApiController(IUserService userService)
+    public UsersApiController(UserService userService, IUserService userDtoService)
     {
         _userService = userService;
+        _userDtoService = userDtoService;
     }
 
     [HttpGet]
     public async Task<ActionResult<List<UserDto>>> GetAll()
     {
-        var users = await _userService.GetAllUsersAsync();
+        var users = await _userDtoService.GetAllUsersAsync();
         return Ok(users);
     }
+
+    [HttpPost]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<ActionResult<UserDto>> Create([FromBody] CreateUserRequest request)
+    {
+        var user = await _userService.CreateUserAsync(request.Email, request.FullName, request.Password, request.Department, request.IsAdmin);
+        var dto = await _userDtoService.GetUserByIdAsync(user.Id);
+        return dto == null ? Problem("Не удалось создать пользователя") : Ok(dto);
+    }
+
+    [HttpPost("register")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Register([FromBody] RegisterRequest request)
+    {
+        await _userService.CreateUserAsync(request.Email, request.FullName, request.Password, request.Department, false);
+        return Ok();
+    }
+
+    public record CreateUserRequest(string Email, string FullName, string Password, string? Department, bool IsAdmin);
+    public record RegisterRequest(string Email, string FullName, string Password, string? Department);
 }

--- a/FileManager.Web/Models/RegisterViewModel.cs
+++ b/FileManager.Web/Models/RegisterViewModel.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace FileManager.Web.Models;
+
+public class RegisterViewModel
+{
+    [Required(ErrorMessage = "Email обязателен")]
+    [EmailAddress(ErrorMessage = "Неверный формат email")]
+    [Display(Name = "Email")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "ФИО обязательно")]
+    [Display(Name = "ФИО")]
+    public string FullName { get; set; } = string.Empty;
+
+    [Display(Name = "Отдел")]
+    public string? Department { get; set; }
+
+    [Required(ErrorMessage = "Пароль обязателен")]
+    [StringLength(100, ErrorMessage = "Пароль должен содержать минимум {2} символов.", MinimumLength = 8)]
+    [RegularExpression(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\\da-zA-Z]).{8,}$",
+        ErrorMessage = "Пароль должен содержать минимум 8 символов, включая заглавную букву, цифру и специальный символ")]
+    [DataType(DataType.Password)]
+    [Display(Name = "Пароль")]
+    public string Password { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Подтверждение пароля обязательно")]
+    [DataType(DataType.Password)]
+    [Compare("Password", ErrorMessage = "Пароли не совпадают")]
+    [Display(Name = "Подтвердите пароль")]
+    public string ConfirmPassword { get; set; } = string.Empty;
+}

--- a/FileManager.Web/Pages/Account/Login.cshtml
+++ b/FileManager.Web/Pages/Account/Login.cshtml
@@ -43,6 +43,7 @@
 
         <div class="login-links">
             <p><a href="/Account/ForgotPassword">Забыли пароль?</a></p>
+            <p><a href="/Account/Register">Регистрация</a></p>
         </div>
 
         <div class="login-info">

--- a/FileManager.Web/Pages/Account/Register.cshtml
+++ b/FileManager.Web/Pages/Account/Register.cshtml
@@ -1,0 +1,62 @@
+@page "/Account/Register"
+@model FileManager.Web.Pages.Account.RegisterModel
+@{
+    ViewData["Title"] = "Регистрация";
+    Layout = "_LoginLayout";
+}
+
+<div class="login-container">
+    <div class="login-card">
+        <h2>FileManager</h2>
+        <p>Регистрация</p>
+
+        @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+        {
+            <div class="alert alert-error">
+                @Model.ErrorMessage
+            </div>
+        }
+
+        <form method="post">
+            <div class="form-group">
+                <label asp-for="RegisterData.Email"></label>
+                <input asp-for="RegisterData.Email" class="form-input" autocomplete="username" />
+                <span asp-validation-for="RegisterData.Email" class="text-error"></span>
+            </div>
+
+            <div class="form-group">
+                <label asp-for="RegisterData.FullName"></label>
+                <input asp-for="RegisterData.FullName" class="form-input" />
+                <span asp-validation-for="RegisterData.FullName" class="text-error"></span>
+            </div>
+
+            <div class="form-group">
+                <label asp-for="RegisterData.Department"></label>
+                <input asp-for="RegisterData.Department" class="form-input" />
+                <span asp-validation-for="RegisterData.Department" class="text-error"></span>
+            </div>
+
+            <div class="form-group">
+                <label asp-for="RegisterData.Password"></label>
+                <input asp-for="RegisterData.Password" type="password" class="form-input" autocomplete="new-password" />
+                <span asp-validation-for="RegisterData.Password" class="text-error"></span>
+            </div>
+
+            <div class="form-group">
+                <label asp-for="RegisterData.ConfirmPassword"></label>
+                <input asp-for="RegisterData.ConfirmPassword" type="password" class="form-input" autocomplete="new-password" />
+                <span asp-validation-for="RegisterData.ConfirmPassword" class="text-error"></span>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Зарегистрироваться</button>
+        </form>
+
+        <div class="login-links">
+            <p><a href="/Account/Login">Уже есть аккаунт?</a></p>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/FileManager.Web/Pages/Account/Register.cshtml.cs
+++ b/FileManager.Web/Pages/Account/Register.cshtml.cs
@@ -1,0 +1,48 @@
+using FileManager.Application.Services;
+using FileManager.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+
+namespace FileManager.Web.Pages.Account;
+
+public class RegisterModel : PageModel
+{
+    private readonly UserService _userService;
+    private readonly ILogger<RegisterModel> _logger;
+
+    [BindProperty]
+    public RegisterViewModel RegisterData { get; set; } = new();
+
+    public string? ErrorMessage { get; set; }
+
+    public RegisterModel(UserService userService, ILogger<RegisterModel> logger)
+    {
+        _userService = userService;
+        _logger = logger;
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        try
+        {
+            await _userService.CreateUserAsync(RegisterData.Email, RegisterData.FullName, RegisterData.Password, RegisterData.Department, false);
+            return RedirectToPage("/Account/Login");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Registration error {Email}", RegisterData.Email);
+            ErrorMessage = ex.Message;
+            return Page();
+        }
+    }
+}

--- a/FileManager.Web/Pages/Admin/Groups.cshtml
+++ b/FileManager.Web/Pages/Admin/Groups.cshtml
@@ -1,0 +1,93 @@
+@page "/Admin/Groups"
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@{
+    ViewData["Title"] = "Группы";
+
+    if (User.FindFirst("IsAdmin")?.Value != "True")
+    {
+        Response.Redirect("/Files");
+        return;
+    }
+}
+
+<h2>Управление группами</h2>
+
+<form id="groupForm" class="mb-3">
+    <input type="text" id="groupName" placeholder="Название группы" required />
+    <button type="submit" class="btn btn-primary">Создать</button>
+</form>
+
+<div id="groupsContainer"></div>
+
+<script>
+async function loadGroups() {
+    const res = await fetch('/api/groups', { credentials: 'include' });
+    const groups = res.ok ? await res.json() : [];
+    const container = document.getElementById('groupsContainer');
+    container.innerHTML = '';
+    for (const g of groups) {
+        const detailsRes = await fetch(`/api/groups/${g.id}`, { credentials: 'include' });
+        const details = detailsRes.ok ? await detailsRes.json() : null;
+        const div = document.createElement('div');
+        div.className = 'group-item';
+        let usersHtml = '';
+        if (details) {
+            usersHtml = '<ul>' + details.users.map(u =>
+                `<li>${u.fullName} <button onclick="removeUser('${g.id}','${u.id}')">Удалить</button></li>`
+            ).join('') + '</ul>';
+        }
+        div.innerHTML = `<h3>${g.name}</h3>` +
+            usersHtml +
+            `<select id="select-${g.id}"></select>` +
+            `<button onclick="addUser('${g.id}')">Добавить пользователя</button>` +
+            `<button onclick="deleteGroup('${g.id}')">Удалить группу</button>`;
+        container.appendChild(div);
+        if (details)
+            await loadAvailableUsers(g.id, details.users.map(u => u.id));
+    }
+}
+
+async function loadAvailableUsers(groupId, existing) {
+    const res = await fetch('/api/users', { credentials: 'include' });
+    const users = res.ok ? await res.json() : [];
+    const select = document.getElementById(`select-${groupId}`);
+    select.innerHTML = users
+        .filter(u => !existing.includes(u.id))
+        .map(u => `<option value="${u.id}">${u.fullName}</option>`)
+        .join('');
+}
+
+async function createGroup(e) {
+    e.preventDefault();
+    const name = document.getElementById('groupName').value;
+    await fetch('/api/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+        credentials: 'include'
+    });
+    document.getElementById('groupName').value = '';
+    await loadGroups();
+}
+
+async function addUser(groupId) {
+    const userId = document.getElementById(`select-${groupId}`).value;
+    if (!userId) return;
+    await fetch(`/api/groups/${groupId}/users/${userId}`, { method: 'POST', credentials: 'include' });
+    await loadGroups();
+}
+
+async function removeUser(groupId, userId) {
+    await fetch(`/api/groups/${groupId}/users/${userId}`, { method: 'DELETE', credentials: 'include' });
+    await loadGroups();
+}
+
+async function deleteGroup(groupId) {
+    await fetch(`/api/groups/${groupId}`, { method: 'DELETE', credentials: 'include' });
+    await loadGroups();
+}
+
+document.getElementById('groupForm').addEventListener('submit', createGroup);
+loadGroups();
+</script>
+

--- a/FileManager.Web/Pages/Admin/Groups.cshtml.cs
+++ b/FileManager.Web/Pages/Admin/Groups.cshtml.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FileManager.Web.Pages.Admin;
+
+[Authorize]
+public class GroupsModel : PageModel
+{
+    public void OnGet()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            Response.Redirect("/Files");
+        }
+    }
+}
+

--- a/FileManager.Web/Pages/Admin/Index.cshtml
+++ b/FileManager.Web/Pages/Admin/Index.cshtml
@@ -52,6 +52,9 @@
         <a class="btn btn-secondary" href="/Admin/Logs">
             Просмотреть логи
         </a>
+        <a class="btn btn-secondary" href="/Admin/Groups">
+            Управление группами
+        </a>
         <button class="btn btn-secondary" onclick="alert('Настройки будут добавлены позже')">
             Настройки системы
         </button>

--- a/FileManager.Web/Pages/Files/_AccessModal.cshtml
+++ b/FileManager.Web/Pages/Files/_AccessModal.cshtml
@@ -38,8 +38,8 @@
 
     async function loadAccessLists() {
         const [usersRes, groupsRes] = await Promise.all([
-            fetch('/api/users'),
-            fetch('/api/groups')
+            fetch('/api/users', { credentials: 'include' }),
+            fetch('/api/groups', { credentials: 'include' })
         ]);
         const users = usersRes.ok ? await usersRes.json() : [];
         const groups = groupsRes.ok ? await groupsRes.json() : [];
@@ -67,7 +67,7 @@
         const url = accessTarget.isFolder
             ? `/api/access/folder/${accessTarget.id}`
             : `/api/access/file/${accessTarget.id}`;
-        const res = await fetch(url);
+        const res = await fetch(url, { credentials: 'include' });
         currentAccess = res.ok ? await res.json() : [];
 
         currentAccess.forEach(r => {
@@ -129,15 +129,19 @@
         });
 
         if (toGrant.length > 0) {
-            await fetch('/api/access/bulk-grant', {
+            const res = await fetch('/api/access/bulk-grant', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ rules: toGrant })
+                body: JSON.stringify({ rules: toGrant }),
+                credentials: 'include'
             });
+            if (!res.ok) {
+                alert('Ошибка сохранения прав доступа');
+            }
         }
 
         for (const id of toRevoke) {
-            await fetch(`/api/access/${id}`, { method: 'DELETE' });
+            await fetch(`/api/access/${id}`, { method: 'DELETE', credentials: 'include' });
         }
 
         closeAccessModal();

--- a/FileManager.Web/Program.cs
+++ b/FileManager.Web/Program.cs
@@ -3,7 +3,6 @@ using FileManager.Infrastructure.Data;
 using FileManager.Application.Services;
 using FileManager.Web.Middleware;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using FileManager.Domain.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -87,12 +86,11 @@ using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     var userService = scope.ServiceProvider.GetRequiredService<UserService>();
-    var yandexDiskService = scope.ServiceProvider.GetRequiredService<IYandexDiskService>();
 
     try
     {
         await context.Database.EnsureCreatedAsync();
-        await DatabaseInitializer.InitializeAsync(context, userService, yandexDiskService);
+        await DatabaseInitializer.InitializeAsync(context, userService);
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
## Summary
- убрано автоматическое создание корневой папки при инициализации БД
- добавлена страница и модель для самостоятельной регистрации пользователей
- расширен UsersApiController методами регистрации и создания пользователя администратором
- на странице входа добавлена ссылка на регистрацию
- исправлена работа модального окна управления доступом: запросы теперь передают cookies и корректно сохраняют выбранных пользователей и группы
- реализованы API для управления группами (создание, добавление и удаление участников, удаление группы) и добавлена админ‑страница для работы с ними

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6891fe38f50883309c7c2dca2b2f5c8d