### PR TITLE
Добавлен интерфейс управления пользователями для администратора

### DIFF
--- a/FileManager.Application/Services/UserService.cs
+++ b/FileManager.Application/Services/UserService.cs
@@ -131,6 +131,27 @@ public class UserService
         return await _userRepository.GetAllAsync();
     }
 
+    public async Task<bool> DeleteUserAsync(Guid userId)
+    {
+        var user = await _userRepository.GetByIdAsync(userId);
+        if (user == null) return false;
+
+        await _userRepository.DeleteAsync(userId);
+        _logger.LogInformation("Удалён пользователь {UserId}", userId);
+        return true;
+    }
+
+    public async Task<User?> SetAdminStatusAsync(Guid userId, bool isAdmin)
+    {
+        var user = await _userRepository.GetByIdAsync(userId);
+        if (user == null) return null;
+
+        user.IsAdmin = isAdmin;
+        await _userRepository.UpdateAsync(user);
+        _logger.LogInformation("Изменён статус администратора пользователя {UserId} на {IsAdmin}", userId, isAdmin);
+        return user;
+    }
+
     public async Task<bool> UserExistsAsync(string email)
     {
         return await _userRepository.ExistsAsync(email);

--- a/FileManager.Web/Controllers/UsersApiController.cs
+++ b/FileManager.Web/Controllers/UsersApiController.cs
@@ -44,6 +44,25 @@ public class UsersApiController : ControllerBase
         return Ok();
     }
 
+    [HttpDelete("{id}")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var deleted = await _userService.DeleteUserAsync(id);
+        return deleted ? NoContent() : NotFound();
+    }
+
+    [HttpPut("{id}/admin")]
+    [Authorize(Policy = "AdminOnly")]
+    public async Task<IActionResult> UpdateAdmin(Guid id, [FromBody] UpdateAdminRequest request)
+    {
+        var user = await _userService.SetAdminStatusAsync(id, request.IsAdmin);
+        if (user == null) return NotFound();
+        var dto = await _userDtoService.GetUserByIdAsync(id);
+        return Ok(dto);
+    }
+
     public record CreateUserRequest(string Email, string FullName, string Password, string? Department, bool IsAdmin);
     public record RegisterRequest(string Email, string FullName, string Password, string? Department);
+    public record UpdateAdminRequest(bool IsAdmin);
 }

--- a/FileManager.Web/Pages/Admin/Index.cshtml
+++ b/FileManager.Web/Pages/Admin/Index.cshtml
@@ -46,14 +46,14 @@
 <div class="admin-actions">
     <h2>Быстрые действия</h2>
     <div class="action-buttons">
-        <a class="btn btn-primary" href="/Admin/CreateUser">
-            Создать пользователя
-        </a>
-        <a class="btn btn-secondary" href="/Admin/Logs">
-            Просмотреть логи
+        <a class="btn btn-primary" href="/Admin/Users">
+            Пользователи
         </a>
         <a class="btn btn-secondary" href="/Admin/Groups">
             Управление группами
+        </a>
+        <a class="btn btn-secondary" href="/Admin/Logs">
+            Просмотреть логи
         </a>
         <button class="btn btn-secondary" onclick="alert('Настройки будут добавлены позже')">
             Настройки системы

--- a/FileManager.Web/Pages/Admin/Users.cshtml
+++ b/FileManager.Web/Pages/Admin/Users.cshtml
@@ -1,0 +1,62 @@
+@page "/Admin/Users"
+@model FileManager.Web.Pages.Admin.UsersModel
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@{
+    ViewData["Title"] = "Пользователи";
+    if (User.FindFirst("IsAdmin")?.Value != "True")
+    {
+        Response.Redirect("/Files");
+        return;
+    }
+}
+
+<h2>Пользователи</h2>
+<a class="btn btn-primary mb-3" href="/Admin/CreateUser">Создать пользователя</a>
+<table class="table table-striped" id="usersTable">
+    <thead>
+        <tr>
+            <th>Email</th>
+            <th>ФИО</th>
+            <th>Отдел</th>
+            <th>Администратор</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+</table>
+
+<script>
+async function loadUsers() {
+    const res = await fetch('/api/users', { credentials: 'include' });
+    const users = res.ok ? await res.json() : [];
+    const tbody = document.querySelector('#usersTable tbody');
+    tbody.innerHTML = '';
+    for (const u of users) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${u.email}</td>
+            <td>${u.fullName}</td>
+            <td>${u.department ?? ''}</td>
+            <td><input type="checkbox" ${u.isAdmin ? 'checked' : ''} onchange="toggleAdmin('${u.id}', this.checked)" /></td>
+            <td><button class="btn btn-secondary btn-small" onclick="deleteUser('${u.id}')">Удалить</button></td>`;
+        tbody.appendChild(tr);
+    }
+}
+
+async function deleteUser(id) {
+    if (!confirm('Удалить пользователя?')) return;
+    await fetch(`/api/users/${id}`, { method: 'DELETE', credentials: 'include' });
+    await loadUsers();
+}
+
+async function toggleAdmin(id, isAdmin) {
+    await fetch(`/api/users/${id}/admin`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ isAdmin }),
+        credentials: 'include'
+    });
+}
+
+loadUsers();
+</script>

--- a/FileManager.Web/Pages/Admin/Users.cshtml.cs
+++ b/FileManager.Web/Pages/Admin/Users.cshtml.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FileManager.Web.Pages.Admin;
+
+[Authorize]
+public class UsersModel : PageModel
+{
+    public void OnGet()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            Response.Redirect("/Files");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- реализована страница администрирования пользователей с таблицей, удалением и переключением прав администратора
- добавлены API‑методы для удаления пользователя и изменения статуса администратора
- на главной странице администрирования добавлена ссылка на управление пользователями

## Testing
- `dotnet build FileManager.Web.sln`
- `dotnet test FileManager.Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_68933d3c678c8330a76c65172fcae291