### PR TITLE
feat: add audit configuration page and options

### DIFF
--- a/FileManager.Application/DTOs/AuditSettingsDto.cs
+++ b/FileManager.Application/DTOs/AuditSettingsDto.cs
@@ -1,0 +1,10 @@
+namespace FileManager.Application.DTOs;
+
+public class AuditSettingsDto
+{
+    public bool EnableFileActions { get; set; } = true;
+    public bool EnableUserActions { get; set; } = true;
+    public bool EnableAccessLog { get; set; } = true;
+    public int RetentionDays { get; set; } = 365;
+    public string LogLevel { get; set; } = "Information";
+}

--- a/FileManager.Application/Interfaces/ISettingsService.cs
+++ b/FileManager.Application/Interfaces/ISettingsService.cs
@@ -12,4 +12,6 @@ public interface ISettingsService
     Task<EmailSettingsDto> GetEmailOptionsAsync();
     Task SaveEmailOptionsAsync(EmailSettingsDto options);
     Task<bool> SendTestEmailAsync(EmailSettingsDto options);
+    Task<AuditSettingsDto> GetAuditOptionsAsync();
+    Task SaveAuditOptionsAsync(AuditSettingsDto options);
 }

--- a/FileManager.Application/Services/SettingsService.cs
+++ b/FileManager.Application/Services/SettingsService.cs
@@ -86,6 +86,30 @@ public class SettingsService : ISettingsService
         await File.WriteAllTextAsync(path, json);
     }
 
+    public Task<AuditSettingsDto> GetAuditOptionsAsync()
+    {
+        var options = new AuditSettingsDto();
+        _configuration.GetSection("Audit").Bind(options);
+        return Task.FromResult(options);
+    }
+
+    public async Task SaveAuditOptionsAsync(AuditSettingsDto options)
+    {
+        var path = Path.Combine(_environment.ContentRootPath, "appsettings.json");
+        JsonNode? root = JsonNode.Parse(await File.ReadAllTextAsync(path)) ?? new JsonObject();
+        var audit = new JsonObject
+        {
+            ["EnableFileActions"] = options.EnableFileActions,
+            ["EnableUserActions"] = options.EnableUserActions,
+            ["EnableAccessLog"] = options.EnableAccessLog,
+            ["RetentionDays"] = options.RetentionDays,
+            ["LogLevel"] = options.LogLevel
+        };
+        root["Audit"] = audit;
+        var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(path, json);
+    }
+
     public Task<EmailSettingsDto> GetEmailOptionsAsync()
     {
         var options = new EmailSettingsDto();

--- a/FileManager.Infrastructure/Configurations/AuditOptions.cs
+++ b/FileManager.Infrastructure/Configurations/AuditOptions.cs
@@ -1,8 +1,14 @@
-﻿public class AuditOptions
+using Microsoft.Extensions.Logging;
+
+namespace FileManager.Infrastructure.Configuration;
+
+public class AuditOptions
 {
     public const string SectionName = "Audit";
 
     public bool EnableFileActions { get; set; } = true;
     public bool EnableUserActions { get; set; } = true;
+    public bool EnableAccessLog { get; set; } = true;
     public int RetentionDays { get; set; } = 365;
+    public LogLevel LogLevel { get; set; } = LogLevel.Information;
 }

--- a/FileManager.Infrastructure/Services/AuditCleanupService.cs
+++ b/FileManager.Infrastructure/Services/AuditCleanupService.cs
@@ -14,6 +14,7 @@ public class AuditCleanupService : BackgroundService
     private readonly ILogger<AuditCleanupService> _logger;
     private readonly TimeSpan _interval = TimeSpan.FromDays(1);
     private readonly int _retentionDays;
+    private readonly LogLevel _logLevel;
 
     public AuditCleanupService(IServiceProvider serviceProvider,
         IOptions<AuditOptions> options,
@@ -22,11 +23,12 @@ public class AuditCleanupService : BackgroundService
         _serviceProvider = serviceProvider;
         _logger = logger;
         _retentionDays = options.Value.RetentionDays;
+        _logLevel = options.Value.LogLevel;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("Audit cleanup service started");
+        _logger.Log(_logLevel, "Audit cleanup service started");
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -42,7 +44,7 @@ public class AuditCleanupService : BackgroundService
             await Task.Delay(_interval, stoppingToken);
         }
 
-        _logger.LogInformation("Audit cleanup service stopped");
+        _logger.Log(_logLevel, "Audit cleanup service stopped");
     }
 
     private async Task CleanupOldLogsAsync()
@@ -61,6 +63,6 @@ public class AuditCleanupService : BackgroundService
         context.AuditLogs.RemoveRange(oldLogs);
         await context.SaveChangesAsync();
 
-        _logger.LogInformation("Removed {Count} audit logs older than {Days} days", oldLogs.Count, _retentionDays);
+        _logger.Log(_logLevel, "Removed {Count} audit logs older than {Days} days", oldLogs.Count, _retentionDays);
     }
 }

--- a/FileManager.Web/Pages/Admin/Settings/Audit.cshtml
+++ b/FileManager.Web/Pages/Admin/Settings/Audit.cshtml
@@ -1,0 +1,48 @@
+@page "/Admin/Settings/Audit"
+@model FileManager.Web.Pages.Admin.Settings.AuditModel
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@{
+    ViewData["Title"] = "Настройки аудита";
+
+    if (User.FindFirst("IsAdmin")?.Value != "True")
+    {
+        Response.Redirect("/Files");
+        return;
+    }
+}
+
+<h2>Настройки аудита</h2>
+
+@if (TempData["Success"] != null)
+{
+    <div class="alert alert-success">@TempData["Success"]</div>
+}
+
+<form method="post">
+    <div class="mb-3 form-check">
+        <input asp-for="EnableFileActions" class="form-check-input" type="checkbox" />
+        <label asp-for="EnableFileActions" class="form-check-label">Логировать действия с файлами</label>
+    </div>
+    <div class="mb-3 form-check">
+        <input asp-for="EnableUserActions" class="form-check-input" type="checkbox" />
+        <label asp-for="EnableUserActions" class="form-check-label">Логировать действия пользователей</label>
+    </div>
+    <div class="mb-3 form-check">
+        <input asp-for="EnableAccessLog" class="form-check-input" type="checkbox" />
+        <label asp-for="EnableAccessLog" class="form-check-label">Логировать управление доступом</label>
+    </div>
+    <div class="mb-3">
+        <label asp-for="LogLevel" class="form-label">Уровень логирования</label>
+        <select asp-for="LogLevel" class="form-select">
+            @foreach (var level in Model.LogLevels)
+            {
+                <option>@level</option>
+            }
+        </select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="RetentionDays" class="form-label">Срок хранения (дней)</label>
+        <input asp-for="RetentionDays" class="form-control" type="number" />
+    </div>
+    <button type="submit" class="btn btn-primary">Сохранить</button>
+</form>

--- a/FileManager.Web/Pages/Admin/Settings/Audit.cshtml.cs
+++ b/FileManager.Web/Pages/Admin/Settings/Audit.cshtml.cs
@@ -1,0 +1,79 @@
+using FileManager.Application.DTOs;
+using FileManager.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FileManager.Web.Pages.Admin.Settings;
+
+[Authorize]
+public class AuditModel : PageModel
+{
+    private readonly ISettingsService _settingsService;
+
+    public AuditModel(ISettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    [BindProperty]
+    public bool EnableFileActions { get; set; }
+
+    [BindProperty]
+    public bool EnableUserActions { get; set; }
+
+    [BindProperty]
+    public bool EnableAccessLog { get; set; }
+
+    [BindProperty]
+    public int RetentionDays { get; set; }
+
+    [BindProperty]
+    public string LogLevel { get; set; } = "Information";
+
+    public List<string> LogLevels { get; } = Enum.GetNames(typeof(Microsoft.Extensions.Logging.LogLevel)).ToList();
+
+    public async Task OnGetAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            Response.Redirect("/Files");
+            return;
+        }
+
+        var options = await _settingsService.GetAuditOptionsAsync();
+        EnableFileActions = options.EnableFileActions;
+        EnableUserActions = options.EnableUserActions;
+        EnableAccessLog = options.EnableAccessLog;
+        RetentionDays = options.RetentionDays;
+        LogLevel = options.LogLevel;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            return Redirect("/Files");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var current = await _settingsService.GetAuditOptionsAsync();
+        current.EnableFileActions = EnableFileActions;
+        current.EnableUserActions = EnableUserActions;
+        current.EnableAccessLog = EnableAccessLog;
+        current.RetentionDays = RetentionDays;
+        current.LogLevel = LogLevel;
+
+        await _settingsService.SaveAuditOptionsAsync(current);
+        TempData["Success"] = "Настройки сохранены";
+        return RedirectToPage();
+    }
+}

--- a/FileManager.Web/appsettings.json
+++ b/FileManager.Web/appsettings.json
@@ -34,7 +34,9 @@
     "Audit": {
         "EnableFileActions": true,
         "EnableUserActions": true,
-        "RetentionDays": 365
+        "EnableAccessLog": true,
+        "RetentionDays": 365,
+        "LogLevel": "Information"
     },
     "Versioning": {
         "MaxVersionsPerFile": 10,


### PR DESCRIPTION
## Summary
- expand audit options with log level and access logging
- introduce admin page to configure audit settings
- respect audit options in infrastructure services

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68942ef318dc8330886b1f127ad71006