### PR TITLE
Добавление страницы прав и сервиса групп

### DIFF
--- a/FileManager.Application/DTOs/GroupAccessDto.cs
+++ b/FileManager.Application/DTOs/GroupAccessDto.cs
@@ -1,0 +1,6 @@
+using FileManager.Domain.Enums;
+using System;
+
+namespace FileManager.Application.DTOs;
+
+public record GroupAccessDto(Guid Id, string Name, AccessType AccessType);

--- a/FileManager.Application/Interfaces/IGroupService.cs
+++ b/FileManager.Application/Interfaces/IGroupService.cs
@@ -1,0 +1,13 @@
+using FileManager.Application.DTOs;
+using FileManager.Domain.Enums;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FileManager.Application.Interfaces;
+
+public interface IGroupService
+{
+    Task<List<GroupAccessDto>> GetGroupPermissionsAsync();
+    Task SetGroupPermissionsAsync(Guid groupId, AccessType accessType, Guid grantedById);
+}

--- a/FileManager.Application/Services/GroupService.cs
+++ b/FileManager.Application/Services/GroupService.cs
@@ -1,0 +1,60 @@
+using FileManager.Application.DTOs;
+using FileManager.Application.Interfaces;
+using FileManager.Domain.Entities;
+using FileManager.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace FileManager.Application.Services;
+
+public class GroupService : IGroupService
+{
+    private readonly IAppDbContext _context;
+
+    public GroupService(IAppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<GroupAccessDto>> GetGroupPermissionsAsync()
+    {
+        return await _context.Groups
+            .Include(g => g.AccessRules)
+            .Select(g => new GroupAccessDto(
+                g.Id,
+                g.Name,
+                g.AccessRules
+                    .Where(r => r.FileId == null && r.FolderId == null)
+                    .Select(r => r.AccessType)
+                    .FirstOrDefault()))
+            .ToListAsync();
+    }
+
+    public async Task SetGroupPermissionsAsync(Guid groupId, AccessType accessType, Guid grantedById)
+    {
+        var rule = await _context.AccessRules
+            .FirstOrDefaultAsync(r => r.GroupId == groupId && r.FileId == null && r.FolderId == null);
+
+        if (rule == null)
+        {
+            rule = new AccessRule
+            {
+                GroupId = groupId,
+                AccessType = accessType,
+                GrantedById = grantedById,
+                InheritFromParent = true
+            };
+            _context.AccessRules.Add(rule);
+        }
+        else
+        {
+            rule.AccessType = accessType;
+            rule.GrantedById = grantedById;
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}

--- a/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
+++ b/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
@@ -55,6 +55,7 @@ public static class ServiceExtensions
         services.AddScoped<IFavoriteService, FavoriteService>();
         services.AddScoped<ITrashService, TrashService>();
         services.AddScoped<ISettingsService, SettingsService>();
+        services.AddScoped<IGroupService, GroupService>();
 
         // Background services
         services.AddHostedService<FileMonitoringService>();

--- a/FileManager.Web/Pages/Admin/Settings/Permissions.cshtml
+++ b/FileManager.Web/Pages/Admin/Settings/Permissions.cshtml
@@ -1,0 +1,52 @@
+@page "/Admin/Settings/Permissions"
+@model FileManager.Web.Pages.Admin.Settings.PermissionsModel
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@{
+    ViewData["Title"] = "Права ролей";
+
+    if (User.FindFirst("IsAdmin")?.Value != "True")
+    {
+        Response.Redirect("/Files");
+        return;
+    }
+}
+
+<h2>Права ролей</h2>
+
+@if (TempData["Success"] != null)
+{
+    <div class="alert alert-success">@TempData["Success"]</div>
+}
+
+<form method="post">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Группа</th>
+                <th>Чтение</th>
+                <th>Запись</th>
+                <th>Удаление</th>
+                <th>Управление доступом</th>
+                <th>Восстановление</th>
+            </tr>
+        </thead>
+        <tbody>
+        @for (int i = 0; i < Model.Groups.Count; i++)
+        {
+            <tr>
+                <td>
+                    @Model.Groups[i].Name
+                    <input type="hidden" asp-for="Groups[i].Id" />
+                    <input type="hidden" asp-for="Groups[i].Name" />
+                </td>
+                <td class="text-center"><input type="checkbox" asp-for="Groups[i].Read" /></td>
+                <td class="text-center"><input type="checkbox" asp-for="Groups[i].Write" /></td>
+                <td class="text-center"><input type="checkbox" asp-for="Groups[i].Delete" /></td>
+                <td class="text-center"><input type="checkbox" asp-for="Groups[i].ManageAccess" /></td>
+                <td class="text-center"><input type="checkbox" asp-for="Groups[i].Restore" /></td>
+            </tr>
+        }
+        </tbody>
+    </table>
+    <button type="submit" class="btn btn-primary">Сохранить</button>
+</form>

--- a/FileManager.Web/Pages/Admin/Settings/Permissions.cshtml.cs
+++ b/FileManager.Web/Pages/Admin/Settings/Permissions.cshtml.cs
@@ -1,0 +1,83 @@
+using FileManager.Application.Interfaces;
+using FileManager.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace FileManager.Web.Pages.Admin.Settings;
+
+[Authorize]
+public class PermissionsModel : PageModel
+{
+    private readonly IGroupService _groupService;
+
+    public PermissionsModel(IGroupService groupService)
+    {
+        _groupService = groupService;
+    }
+
+    [BindProperty]
+    public List<GroupPermissionViewModel> Groups { get; set; } = new();
+
+    public class GroupPermissionViewModel
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public bool Read { get; set; }
+        public bool Write { get; set; }
+        public bool Delete { get; set; }
+        public bool ManageAccess { get; set; }
+        public bool Restore { get; set; }
+    }
+
+    public async Task OnGetAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            Response.Redirect("/Files");
+            return;
+        }
+
+        var groups = await _groupService.GetGroupPermissionsAsync();
+        Groups = groups.Select(g => new GroupPermissionViewModel
+        {
+            Id = g.Id,
+            Name = g.Name,
+            Read = g.AccessType.HasFlag(AccessType.Read),
+            Write = g.AccessType.HasFlag(AccessType.Write),
+            Delete = g.AccessType.HasFlag(AccessType.Delete),
+            ManageAccess = g.AccessType.HasFlag(AccessType.ManageAccess),
+            Restore = g.AccessType.HasFlag(AccessType.Restore)
+        }).ToList();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            return Redirect("/Files");
+        }
+
+        var userId = Guid.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+
+        foreach (var group in Groups)
+        {
+            var access = AccessType.None;
+            if (group.Read) access |= AccessType.Read;
+            if (group.Write) access |= AccessType.Write;
+            if (group.Delete) access |= AccessType.Delete;
+            if (group.ManageAccess) access |= AccessType.ManageAccess;
+            if (group.Restore) access |= AccessType.Restore;
+
+            await _groupService.SetGroupPermissionsAsync(group.Id, access, userId);
+        }
+
+        TempData["Success"] = "Права обновлены";
+        return RedirectToPage();
+    }
+}


### PR DESCRIPTION
## Summary
- реализован интерфейс и сервис для управления правами групп
- добавлена Razor-страница настроек с таблицей разрешений
- зарегистрирован новый сервис в контейнере зависимостей

## Testing
- `dotnet build FileManager.Web.sln`
- `dotnet test FileManager.Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_689433a3aef08330b7c29b8785d4c449