### PR TITLE
Add theme configuration and settings page

### DIFF
--- a/FileManager.Application/DTOs/ThemeSettingsDto.cs
+++ b/FileManager.Application/DTOs/ThemeSettingsDto.cs
@@ -1,0 +1,8 @@
+namespace FileManager.Application.DTOs;
+
+public class ThemeSettingsDto
+{
+    public string Theme { get; set; } = "light";
+    public string LogoUrl { get; set; } = string.Empty;
+    public string AccentColor { get; set; } = "#0d6efd";
+}

--- a/FileManager.Application/Interfaces/ISettingsService.cs
+++ b/FileManager.Application/Interfaces/ISettingsService.cs
@@ -16,4 +16,6 @@ public interface ISettingsService
     Task SaveAuditOptionsAsync(AuditSettingsDto options);
     Task<VersioningSettingsDto> GetVersioningOptionsAsync();
     Task SaveVersioningOptionsAsync(VersioningSettingsDto options);
+    Task<ThemeSettingsDto> GetThemeOptionsAsync();
+    Task SaveThemeOptionsAsync(ThemeSettingsDto options);
 }

--- a/FileManager.Application/Services/SettingsService.cs
+++ b/FileManager.Application/Services/SettingsService.cs
@@ -164,6 +164,28 @@ public class SettingsService : ISettingsService
         await File.WriteAllTextAsync(path, json);
     }
 
+    public Task<ThemeSettingsDto> GetThemeOptionsAsync()
+    {
+        var options = new ThemeSettingsDto();
+        _configuration.GetSection("Theme").Bind(options);
+        return Task.FromResult(options);
+    }
+
+    public async Task SaveThemeOptionsAsync(ThemeSettingsDto options)
+    {
+        var path = Path.Combine(_environment.ContentRootPath, "appsettings.json");
+        JsonNode? root = JsonNode.Parse(await File.ReadAllTextAsync(path)) ?? new JsonObject();
+        var theme = new JsonObject
+        {
+            ["Theme"] = options.Theme,
+            ["LogoUrl"] = options.LogoUrl,
+            ["AccentColor"] = options.AccentColor
+        };
+        root["Theme"] = theme;
+        var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(path, json);
+    }
+
     public async Task<bool> SendTestEmailAsync(EmailSettingsDto options)
     {
         try

--- a/FileManager.Infrastructure/Configurations/ThemeOptions.cs
+++ b/FileManager.Infrastructure/Configurations/ThemeOptions.cs
@@ -1,0 +1,10 @@
+namespace FileManager.Infrastructure.Configuration;
+
+public class ThemeOptions
+{
+    public const string SectionName = "Theme";
+
+    public string Theme { get; set; } = "light";
+    public string LogoUrl { get; set; } = string.Empty;
+    public string AccentColor { get; set; } = "#0d6efd";
+}

--- a/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
+++ b/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceExtensions
         services.Configure<AuditOptions>(configuration.GetSection(AuditOptions.SectionName));
         services.Configure<VersioningOptions>(configuration.GetSection(VersioningOptions.SectionName));
         services.Configure<SecurityOptions>(configuration.GetSection(SecurityOptions.SectionName));
+        services.Configure<ThemeOptions>(configuration.GetSection(ThemeOptions.SectionName));
 
         // Адаптер
         services.AddScoped<IFileStorageOptions, FileStorageOptionsAdapter>();

--- a/FileManager.Web/Pages/Admin/Settings/Theme.cshtml
+++ b/FileManager.Web/Pages/Admin/Settings/Theme.cshtml
@@ -1,0 +1,35 @@
+@page "/Admin/Settings/Theme"
+@model FileManager.Web.Pages.Admin.Settings.ThemeModel
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@{
+    ViewData["Title"] = "Настройки темы";
+
+    if (User.FindFirst("IsAdmin")?.Value != "True")
+    {
+        Response.Redirect("/Files");
+        return;
+    }
+}
+
+<h2>Настройки темы</h2>
+
+@if (TempData["Success"] != null)
+{
+    <div class="alert alert-success">@TempData["Success"]</div>
+}
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Theme" class="form-label">Тема</label>
+        <input asp-for="Theme" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="LogoUrl" class="form-label">URL логотипа</label>
+        <input asp-for="LogoUrl" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="AccentColor" class="form-label">Цвет акцента</label>
+        <input asp-for="AccentColor" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Сохранить</button>
+</form>

--- a/FileManager.Web/Pages/Admin/Settings/Theme.cshtml.cs
+++ b/FileManager.Web/Pages/Admin/Settings/Theme.cshtml.cs
@@ -1,0 +1,62 @@
+using FileManager.Application.DTOs;
+using FileManager.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FileManager.Web.Pages.Admin.Settings;
+
+[Authorize]
+public class ThemeModel : PageModel
+{
+    private readonly ISettingsService _settingsService;
+
+    public ThemeModel(ISettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    [BindProperty]
+    public string Theme { get; set; } = string.Empty;
+
+    [BindProperty]
+    public string LogoUrl { get; set; } = string.Empty;
+
+    [BindProperty]
+    public string AccentColor { get; set; } = string.Empty;
+
+    public async Task OnGetAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            Response.Redirect("/Files");
+            return;
+        }
+
+        var options = await _settingsService.GetThemeOptionsAsync();
+        Theme = options.Theme;
+        LogoUrl = options.LogoUrl;
+        AccentColor = options.AccentColor;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            return Redirect("/Files");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var current = await _settingsService.GetThemeOptionsAsync();
+        current.Theme = Theme;
+        current.LogoUrl = LogoUrl;
+        current.AccentColor = AccentColor;
+        await _settingsService.SaveThemeOptionsAsync(current);
+        TempData["Success"] = "Настройки сохранены";
+        return RedirectToPage();
+    }
+}

--- a/FileManager.Web/Pages/Shared/_Layout.cshtml
+++ b/FileManager.Web/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,6 @@
 ﻿<!DOCTYPE html>
+@using FileManager.Infrastructure.Configuration
+@inject Microsoft.Extensions.Options.IOptions<ThemeOptions> ThemeOptions
 <html lang="ru">
 <head>
     <meta charset="utf-8" />
@@ -7,12 +9,22 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
 </head>
-<body>
+@{ var theme = ThemeOptions.Value; }
+<body class="@theme.Theme" style="--accent-color: @theme.AccentColor;">
     @if (User.Identity?.IsAuthenticated == true)
     {
         <div class="app-shell">
             <aside class="sidebar">
-                <div class="sidebar-logo">FileManager</div>
+                <div class="sidebar-logo">
+                    @if (!string.IsNullOrEmpty(theme.LogoUrl))
+                    {
+                        <img src="@theme.LogoUrl" alt="Logo" />
+                    }
+                    else
+                    {
+                        <span>FileManager</span>
+                    }
+                </div>
                 <a href="/Files" class="sidebar-link"><i class="bi bi-folder"></i> Мои документы</a>
                 @if (User.FindFirst("IsAdmin")?.Value == "True")
                 {


### PR DESCRIPTION
## Summary
- Добавлен класс `ThemeOptions` и DTO для настроек темы.
- Добавлена страница админ-панели для управления темой, логотипом и цветом акцента.
- Значения темы подключены через DI и используются в макете.

## Testing
- `dotnet build`

## Issue
- Нет связанного issue.

------
https://chatgpt.com/codex/tasks/task_e_6894358541a08330b2f7b825be69facf