### PR TITLE
feat: add cleanup options and background tasks

### DIFF
--- a/FileManager.Application/DTOs/CleanupSettingsDto.cs
+++ b/FileManager.Application/DTOs/CleanupSettingsDto.cs
@@ -1,0 +1,7 @@
+namespace FileManager.Application.DTOs;
+
+public class CleanupSettingsDto
+{
+    public int TrashRetentionDays { get; set; } = 30;
+    public int ArchiveCleanupDays { get; set; } = 365;
+}

--- a/FileManager.Application/Interfaces/ICleanupOptions.cs
+++ b/FileManager.Application/Interfaces/ICleanupOptions.cs
@@ -1,0 +1,7 @@
+namespace FileManager.Application.Interfaces;
+
+public interface ICleanupOptions
+{
+    int TrashRetentionDays { get; }
+    int ArchiveCleanupDays { get; }
+}

--- a/FileManager.Application/Interfaces/ISettingsService.cs
+++ b/FileManager.Application/Interfaces/ISettingsService.cs
@@ -20,4 +20,6 @@ public interface ISettingsService
     Task SaveThemeOptionsAsync(ThemeSettingsDto options);
     Task<UploadSecuritySettingsDto> GetUploadSecurityOptionsAsync();
     Task SaveUploadSecurityOptionsAsync(UploadSecuritySettingsDto options);
+    Task<CleanupSettingsDto> GetCleanupOptionsAsync();
+    Task SaveCleanupOptionsAsync(CleanupSettingsDto options);
 }

--- a/FileManager.Application/Services/ArchiveCleanupService.cs
+++ b/FileManager.Application/Services/ArchiveCleanupService.cs
@@ -1,0 +1,81 @@
+using FileManager.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.IO;
+using System.Linq;
+
+namespace FileManager.Application.Services;
+
+public class ArchiveCleanupService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ArchiveCleanupService> _logger;
+    private readonly ICleanupOptions _options;
+    private readonly TimeSpan _interval = TimeSpan.FromDays(1);
+
+    public ArchiveCleanupService(IServiceProvider serviceProvider,
+        ICleanupOptions options,
+        ILogger<ArchiveCleanupService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Archive cleanup service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await CleanupArchiveAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during archive cleanup");
+            }
+
+            await Task.Delay(_interval, stoppingToken);
+        }
+
+        _logger.LogInformation("Archive cleanup service stopped");
+    }
+
+    private async Task CleanupArchiveAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<IAppDbContext>();
+
+        var cutoff = DateTime.UtcNow.AddDays(-_options.ArchiveCleanupDays);
+        var oldVersions = await context.FileVersions
+            .Where(v => v.CreatedAt < cutoff)
+            .ToListAsync();
+
+        if (oldVersions.Count == 0)
+            return;
+
+        foreach (var version in oldVersions)
+        {
+            if (version.LocalArchivePath != null && File.Exists(version.LocalArchivePath))
+            {
+                try
+                {
+                    File.Delete(version.LocalArchivePath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error deleting archive file {Path}", version.LocalArchivePath);
+                }
+            }
+        }
+
+        context.FileVersions.RemoveRange(oldVersions);
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Removed {Count} archived versions older than {Days} days", oldVersions.Count, _options.ArchiveCleanupDays);
+    }
+}

--- a/FileManager.Application/Services/SettingsService.cs
+++ b/FileManager.Application/Services/SettingsService.cs
@@ -208,6 +208,27 @@ public class SettingsService : ISettingsService
         await File.WriteAllTextAsync(path, json);
     }
 
+    public Task<CleanupSettingsDto> GetCleanupOptionsAsync()
+    {
+        var options = new CleanupSettingsDto();
+        _configuration.GetSection("Cleanup").Bind(options);
+        return Task.FromResult(options);
+    }
+
+    public async Task SaveCleanupOptionsAsync(CleanupSettingsDto options)
+    {
+        var path = Path.Combine(_environment.ContentRootPath, "appsettings.json");
+        JsonNode? root = JsonNode.Parse(await File.ReadAllTextAsync(path)) ?? new JsonObject();
+        var cleanup = new JsonObject
+        {
+            ["TrashRetentionDays"] = options.TrashRetentionDays,
+            ["ArchiveCleanupDays"] = options.ArchiveCleanupDays
+        };
+        root["Cleanup"] = cleanup;
+        var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(path, json);
+    }
+
     public async Task<bool> SendTestEmailAsync(EmailSettingsDto options)
     {
         try

--- a/FileManager.Application/Services/TrashCleanupService.cs
+++ b/FileManager.Application/Services/TrashCleanupService.cs
@@ -1,0 +1,83 @@
+using FileManager.Application.Interfaces;
+using FileManager.Domain.Enums;
+using FileManager.Domain.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+
+namespace FileManager.Application.Services;
+
+public class TrashCleanupService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<TrashCleanupService> _logger;
+    private readonly ICleanupOptions _options;
+    private readonly TimeSpan _interval = TimeSpan.FromDays(1);
+
+    public TrashCleanupService(IServiceProvider serviceProvider,
+        ICleanupOptions options,
+        ILogger<TrashCleanupService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Trash cleanup service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await CleanupTrashAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during trash cleanup");
+            }
+
+            await Task.Delay(_interval, stoppingToken);
+        }
+
+        _logger.LogInformation("Trash cleanup service stopped");
+    }
+
+    private async Task CleanupTrashAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var filesRepository = scope.ServiceProvider.GetRequiredService<IFilesRepository>();
+        var folderRepository = scope.ServiceProvider.GetRequiredService<IFolderRepository>();
+        var yandexDiskService = scope.ServiceProvider.GetRequiredService<IYandexDiskService>();
+        var auditService = scope.ServiceProvider.GetRequiredService<IAuditService>();
+
+        var cutoff = DateTime.UtcNow.AddDays(-_options.TrashRetentionDays);
+
+        var files = await filesRepository.GetDeletedAsync();
+        foreach (var file in files.Where(f => f.DeletedAt.HasValue && f.DeletedAt.Value < cutoff))
+        {
+            try
+            {
+                await yandexDiskService.DeleteFileAsync(file.YandexPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error deleting file {Path}", file.YandexPath);
+            }
+
+            await filesRepository.HardDeleteAsync(file.Id);
+            await auditService.LogAsync(AuditAction.FileDelete, file.UploadedById, fileId: file.Id,
+                description: "Файл удалён автоматически из корзины");
+        }
+
+        var folders = await folderRepository.GetDeletedAsync();
+        foreach (var folder in folders.Where(f => f.DeletedAt.HasValue && f.DeletedAt.Value < cutoff))
+        {
+            await folderRepository.HardDeleteAsync(folder.Id);
+            await auditService.LogAsync(AuditAction.FolderDelete, folder.CreatedById, folderId: folder.Id,
+                description: "Папка удалена автоматически из корзины");
+        }
+    }
+}

--- a/FileManager.Infrastructure/Configurations/CleanupOptions.cs
+++ b/FileManager.Infrastructure/Configurations/CleanupOptions.cs
@@ -1,0 +1,9 @@
+namespace FileManager.Infrastructure.Configuration;
+
+public class CleanupOptions
+{
+    public const string SectionName = "Cleanup";
+
+    public int TrashRetentionDays { get; set; } = 30;
+    public int ArchiveCleanupDays { get; set; } = 365;
+}

--- a/FileManager.Infrastructure/Configurations/CleanupOptionsAdapter.cs
+++ b/FileManager.Infrastructure/Configurations/CleanupOptionsAdapter.cs
@@ -1,0 +1,17 @@
+using FileManager.Application.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace FileManager.Infrastructure.Configuration;
+
+public class CleanupOptionsAdapter : ICleanupOptions
+{
+    private readonly CleanupOptions _options;
+
+    public CleanupOptionsAdapter(IOptions<CleanupOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public int TrashRetentionDays => _options.TrashRetentionDays;
+    public int ArchiveCleanupDays => _options.ArchiveCleanupDays;
+}

--- a/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
+++ b/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
@@ -29,10 +29,12 @@ public static class ServiceExtensions
         services.Configure<SecurityOptions>(configuration.GetSection(SecurityOptions.SectionName));
         services.Configure<ThemeOptions>(configuration.GetSection(ThemeOptions.SectionName));
         services.Configure<UploadSecurityOptions>(configuration.GetSection(UploadSecurityOptions.SectionName));
+        services.Configure<CleanupOptions>(configuration.GetSection(CleanupOptions.SectionName));
 
         // Адаптер
         services.AddScoped<IFileStorageOptions, FileStorageOptionsAdapter>();
         services.AddScoped<IVersioningOptions, VersioningOptionsAdapter>();
+        services.AddScoped<ICleanupOptions, CleanupOptionsAdapter>();
 
         // Репозитории
         services.AddScoped<IUserRepository, UserRepository>();
@@ -63,6 +65,8 @@ public static class ServiceExtensions
         // Background services
         services.AddHostedService<FileMonitoringService>();
         services.AddHostedService<AuditCleanupService>();
+        services.AddHostedService<TrashCleanupService>();
+        services.AddHostedService<ArchiveCleanupService>();
 
         return services;
     }

--- a/FileManager.Web/Pages/Admin/Settings/Cleanup.cshtml
+++ b/FileManager.Web/Pages/Admin/Settings/Cleanup.cshtml
@@ -1,0 +1,31 @@
+@page "/Admin/Settings/Cleanup"
+@model FileManager.Web.Pages.Admin.Settings.CleanupModel
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@{
+    ViewData["Title"] = "Очистка";
+
+    if (User.FindFirst("IsAdmin")?.Value != "True")
+    {
+        Response.Redirect("/Files");
+        return;
+    }
+}
+
+<h2>Очистка</h2>
+
+@if (TempData["Success"] != null)
+{
+    <div class="alert alert-success">@TempData["Success"]</div>
+}
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="TrashRetentionDays" class="form-label">Срок хранения в корзине (дней)</label>
+        <input asp-for="TrashRetentionDays" class="form-control" type="number" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="ArchiveCleanupDays" class="form-label">Срок хранения архива версий (дней)</label>
+        <input asp-for="ArchiveCleanupDays" class="form-control" type="number" />
+    </div>
+    <button type="submit" class="btn btn-primary">Сохранить</button>
+</form>

--- a/FileManager.Web/Pages/Admin/Settings/Cleanup.cshtml.cs
+++ b/FileManager.Web/Pages/Admin/Settings/Cleanup.cshtml.cs
@@ -1,0 +1,55 @@
+using FileManager.Application.DTOs;
+using FileManager.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FileManager.Web.Pages.Admin.Settings;
+
+[Authorize]
+public class CleanupModel : PageModel
+{
+    private readonly ISettingsService _settingsService;
+
+    public CleanupModel(ISettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    [BindProperty]
+    public int TrashRetentionDays { get; set; }
+
+    [BindProperty]
+    public int ArchiveCleanupDays { get; set; }
+
+    public async Task OnGetAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            Response.Redirect("/Files");
+            return;
+        }
+
+        var options = await _settingsService.GetCleanupOptionsAsync();
+        TrashRetentionDays = options.TrashRetentionDays;
+        ArchiveCleanupDays = options.ArchiveCleanupDays;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (User.FindFirst("IsAdmin")?.Value != "True")
+        {
+            return Redirect("/Files");
+        }
+
+        if (!ModelState.IsValid)
+            return Page();
+
+        var current = await _settingsService.GetCleanupOptionsAsync();
+        current.TrashRetentionDays = TrashRetentionDays;
+        current.ArchiveCleanupDays = ArchiveCleanupDays;
+        await _settingsService.SaveCleanupOptionsAsync(current);
+        TempData["Success"] = "Настройки сохранены";
+        return RedirectToPage();
+    }
+}


### PR DESCRIPTION
## Summary
- add cleanup options for trash and archive
- add cleanup settings page for admins
- implement background services to purge old trash and archived versions

## Testing
- `dotnet build FileManager.Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_68943af0b6b88330880eea6a20ef86bb