### PR TITLE
Fix cleanup options lifetime for background services

### DIFF
--- a/FileManager.Infrastructure/Configurations/AccessRuleConfiguration.cs
+++ b/FileManager.Infrastructure/Configurations/AccessRuleConfiguration.cs
@@ -44,7 +44,7 @@ public class AccessRuleConfiguration : IEntityTypeConfiguration<AccessRule>
 
         // Исправленные Check Constraints с правильными именами столбцов PostgreSQL
         builder.HasCheckConstraint("CK_AccessRules_FileOrFolder",
-            "(\"FileId\" IS NOT NULL AND \"FolderId\" IS NULL) OR (\"FileId\" IS NULL AND \"FolderId\" IS NOT NULL)");
+            "(\"FileId\" IS NOT NULL AND \"FolderId\" IS NULL) OR (\"FileId\" IS NULL AND \"FolderId\" IS NOT NULL) OR (\"FileId\" IS NULL AND \"FolderId\" IS NULL)");
 
         builder.HasCheckConstraint("CK_AccessRules_UserOrGroup",
             "(\"UserId\" IS NOT NULL AND \"GroupId\" IS NULL) OR (\"UserId\" IS NULL AND \"GroupId\" IS NOT NULL)");

--- a/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
+++ b/FileManager.Infrastructure/Extensions/ServiceExtensions.cs
@@ -34,7 +34,7 @@ public static class ServiceExtensions
         // Адаптер
         services.AddScoped<IFileStorageOptions, FileStorageOptionsAdapter>();
         services.AddScoped<IVersioningOptions, VersioningOptionsAdapter>();
-        services.AddScoped<ICleanupOptions, CleanupOptionsAdapter>();
+        services.AddSingleton<ICleanupOptions, CleanupOptionsAdapter>();
 
         // Репозитории
         services.AddScoped<IUserRepository, UserRepository>();

--- a/FileManager.Infrastructure/Migrations/20250807061728_AllowGlobalAccessRule.Designer.cs
+++ b/FileManager.Infrastructure/Migrations/20250807061728_AllowGlobalAccessRule.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FileManager.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FileManager.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250807061728_AllowGlobalAccessRule")]
+    partial class AllowGlobalAccessRule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FileManager.Infrastructure/Migrations/20250807061728_AllowGlobalAccessRule.cs
+++ b/FileManager.Infrastructure/Migrations/20250807061728_AllowGlobalAccessRule.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FileManager.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllowGlobalAccessRule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_AccessRules_FileOrFolder",
+                table: "access_rules");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_AccessRules_FileOrFolder",
+                table: "access_rules",
+                sql: "(\"FileId\" IS NOT NULL AND \"FolderId\" IS NULL) OR (\"FileId\" IS NULL AND \"FolderId\" IS NOT NULL) OR (\"FileId\" IS NULL AND \"FolderId\" IS NULL)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_AccessRules_FileOrFolder",
+                table: "access_rules");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_AccessRules_FileOrFolder",
+                table: "access_rules",
+                sql: "(\"FileId\" IS NOT NULL AND \"FolderId\" IS NULL) OR (\"FileId\" IS NULL AND \"FolderId\" IS NOT NULL)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- change ICleanupOptions lifetime to singleton so background cleanup services resolve correctly
- relax access rule constraint to allow global group permissions

## Testing
- `dotnet build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689427a6c7ac8330b1a36f5679f14b0b