### PR TITLE
Использование глобального контейнера уведомлений

### DIFF
--- a/FileManager.Web/Pages/Files/Index.cshtml
+++ b/FileManager.Web/Pages/Files/Index.cshtml
@@ -88,4 +88,4 @@
         <li data-action="properties" title="Свойства"><i class="bi bi-info-circle"></i></li>
     </ul>
 </div>
-<div id="notificationContainer" class="notification-container"></div>
+

--- a/FileManager.Web/Pages/Shared/_Layout.cshtml
+++ b/FileManager.Web/Pages/Shared/_Layout.cshtml
@@ -61,5 +61,6 @@
     <script src="~/js/files-manager.js" asp-append-version="true"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
+    <div id="notificationContainer" class="notification-container"></div>
 </body>
 </html>

--- a/FileManager.Web/wwwroot/js/files-manager.js
+++ b/FileManager.Web/wwwroot/js/files-manager.js
@@ -649,13 +649,9 @@ class FilesManager {
 
     // Utility method for notifications
     showNotification(message, type = 'info') {
-        const container = document.getElementById('notificationContainer');
-        if (!container) return;
-        const notification = document.createElement('div');
-        notification.className = `notification notification-${type}`;
-        notification.textContent = message;
-        container.appendChild(notification);
-        setTimeout(() => notification.remove(), 5000);
+        if (typeof window.showNotification === 'function') {
+            window.showNotification(message, type);
+        }
     }
 
     // Utility functions

--- a/FileManager.Web/wwwroot/js/site.js
+++ b/FileManager.Web/wwwroot/js/site.js
@@ -42,3 +42,16 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 });
+
+window.showNotification = function (message, type = 'info') {
+    const container = document.getElementById('notificationContainer');
+    if (!container) {
+        return;
+    }
+    const notification = document.createElement('div');
+    notification.className = `notification notification-${type}`;
+    notification.textContent = message;
+    container.appendChild(notification);
+    setTimeout(() => notification.remove(), 5000);
+};
+


### PR DESCRIPTION
## Summary
- добавлен глобальный контейнер уведомлений в макете
- удалён локальный контейнер на странице файлов
- все вызовы `showNotification` используют глобальный контейнер

## Testing
- `dotnet build`
- `dotnet test` (тестов не найдено)


------
https://chatgpt.com/codex/tasks/task_e_6894609b394c8330ad05a6c295e31359