### PR TITLE
Добавлены иконки по типу файла и стили выделения

### DIFF
--- a/FileManager.Web/Pages/Files/_ExplorerList.cshtml
+++ b/FileManager.Web/Pages/Files/_ExplorerList.cshtml
@@ -7,7 +7,14 @@
     {
         <div class="tile-row explorer-item" data-type="@item.Type" data-id="@item.Id" data-name="@item.Name">
             <div class="tile-icon">
-                <i class="@item.IconClass"></i>
+                @if (item.Type == "folder")
+                {
+                    <i class="bi bi-folder"></i>
+                }
+                else
+                {
+                    @Html.Raw(GetFileIcon(item.Extension))
+                }
                 @if (item.IsNetworkAvailable)
                 {
                     <i class="bi bi-cloud-check network-icon"></i>
@@ -35,6 +42,24 @@ else
 }
 
 @functions {
+    private string GetFileIcon(string? extension)
+    {
+        var ext = extension?.ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" or ".svg" => "<i class='bi bi-file-earmark-image'></i>",
+            ".pdf" => "<i class='bi bi-file-earmark-pdf'></i>",
+            ".zip" or ".rar" or ".7z" => "<i class='bi bi-file-earmark-zip'></i>",
+            ".mp3" or ".wav" or ".flac" => "<i class='bi bi-file-earmark-music'></i>",
+            ".mp4" or ".avi" or ".mov" or ".mkv" => "<i class='bi bi-file-earmark-play'></i>",
+            ".doc" or ".docx" => "<i class='bi bi-file-earmark-word'></i>",
+            ".xls" or ".xlsx" => "<i class='bi bi-file-earmark-excel'></i>",
+            ".ppt" or ".pptx" => "<i class='bi bi-file-earmark-ppt'></i>",
+            ".txt" or ".md" => "<i class='bi bi-file-earmark-text'></i>",
+            _ => "<i class='bi bi-file-earmark'></i>"
+        };
+    }
+
     private string FormatSize(long size)
     {
         string[] suffix = { "Б", "КБ", "МБ", "ГБ", "ТБ" };

--- a/FileManager.Web/Pages/Files/_FilesGrid.cshtml
+++ b/FileManager.Web/Pages/Files/_FilesGrid.cshtml
@@ -37,7 +37,7 @@
         {
             <div class="file-card explorer-item" data-type="file" data-id="@item.Id" data-name="@item.Name">
                 <div class="file-card-icon">
-                    <i class="@item.IconClass"></i>
+                    @Html.Raw(GetFileIcon(item.Extension))
                     @if (item.IsNetworkAvailable)
                     {
                         <i class="bi bi-cloud-check network-icon"></i>
@@ -92,6 +92,24 @@ else
 </script>
 
 @functions {
+    private string GetFileIcon(string? extension)
+    {
+        var ext = extension?.ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" or ".svg" => "<i class='bi bi-file-earmark-image'></i>",
+            ".pdf" => "<i class='bi bi-file-earmark-pdf'></i>",
+            ".zip" or ".rar" or ".7z" => "<i class='bi bi-file-earmark-zip'></i>",
+            ".mp3" or ".wav" or ".flac" => "<i class='bi bi-file-earmark-music'></i>",
+            ".mp4" or ".avi" or ".mov" or ".mkv" => "<i class='bi bi-file-earmark-play'></i>",
+            ".doc" or ".docx" => "<i class='bi bi-file-earmark-word'></i>",
+            ".xls" or ".xlsx" => "<i class='bi bi-file-earmark-excel'></i>",
+            ".ppt" or ".pptx" => "<i class='bi bi-file-earmark-ppt'></i>",
+            ".txt" or ".md" => "<i class='bi bi-file-earmark-text'></i>",
+            _ => "<i class='bi bi-file-earmark'></i>"
+        };
+    }
+
     private string FormatSize(long size)
     {
         string[] suffix = { "Б", "КБ", "МБ", "ГБ", "ТБ" };

--- a/FileManager.Web/wwwroot/css/site.css
+++ b/FileManager.Web/wwwroot/css/site.css
@@ -2155,3 +2155,18 @@ body {
 
 @keyframes pageFadeIn { from { opacity: 0; } to { opacity: 1; } }
 @keyframes pageFadeOut { from { opacity: 1; } to { opacity: 0; } }
+
+/* Hover and selection styles for explorer items */
+.file-card:hover,
+.file-card.selected {
+    border-color: var(--accent-color);
+    background-color: var(--accent-color);
+    color: #fff;
+}
+
+.explorer-item:hover,
+.explorer-item.selected {
+    border-color: var(--accent-color);
+    background-color: var(--accent-color);
+    color: #fff;
+}

--- a/FileManager.Web/wwwroot/js/files-manager.js
+++ b/FileManager.Web/wwwroot/js/files-manager.js
@@ -223,12 +223,26 @@ class FilesManager {
                 document.querySelectorAll('.file-select').forEach(cb => {
                     cb.checked = checked;
                     const id = cb.dataset.fileId;
-                    if (checked) this.selectedFiles.add(id); else this.selectedFiles.delete(id);
+                    const row = cb.closest('.explorer-item');
+                    if (checked) {
+                        this.selectedFiles.add(id);
+                        row?.classList.add('selected');
+                    } else {
+                        this.selectedFiles.delete(id);
+                        row?.classList.remove('selected');
+                    }
                 });
                 this.updateDownloadButton();
             } else if (e.target.classList.contains('file-select')) {
                 const id = e.target.dataset.fileId;
-                if (e.target.checked) this.selectedFiles.add(id); else this.selectedFiles.delete(id);
+                const row = e.target.closest('.explorer-item');
+                if (e.target.checked) {
+                    this.selectedFiles.add(id);
+                    row?.classList.add('selected');
+                } else {
+                    this.selectedFiles.delete(id);
+                    row?.classList.remove('selected');
+                }
                 this.updateDownloadButton();
             }
         });


### PR DESCRIPTION
## Summary
- Отображение Bootstrap-иконок по расширению файла в сетке и списке проводника
- Добавлены hover/selected стили для элементов проводника с использованием `--accent-color`
- Подсветка выбранных файлов через класс `.selected`

## Testing
- `dotnet test FileManager.Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_6895d1ee63008330874230b4788cab51