### PR TITLE
Добавлены SVG-иконки файлов и логика их выбора

### DIFF
--- a/FileManager.Application/DTOs/FolderDto.cs
+++ b/FileManager.Application/DTOs/FolderDto.cs
@@ -34,6 +34,7 @@ public class TreeNodeDto
     public string Name { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty; // "folder" or "file"
     public string IconClass { get; set; } = string.Empty;
+    public string IconName => GetIconName();
     public bool IsNetworkAvailable { get; set; } = true;
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
@@ -52,4 +53,25 @@ public class TreeNodeDto
     public bool HasChildren { get; set; }
     public bool IsExpanded { get; set; } = false;
     public int Level { get; set; } = 0;
+
+    private string GetIconName()
+    {
+        if (Type == "folder")
+            return "folder";
+
+        var ext = Extension?.ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" or ".svg" => "image",
+            ".pdf" => "pdf",
+            ".zip" or ".rar" or ".7z" => "archive",
+            ".mp3" or ".wav" or ".flac" => "audio",
+            ".mp4" or ".avi" or ".mov" or ".mkv" => "video",
+            ".doc" or ".docx" => "docx",
+            ".xls" or ".xlsx" => "xlsx",
+            ".ppt" or ".pptx" => "pptx",
+            ".txt" or ".md" => "txt",
+            _ => "file"
+        };
+    }
 }

--- a/FileManager.Web/Pages/Files/_ExplorerList.cshtml
+++ b/FileManager.Web/Pages/Files/_ExplorerList.cshtml
@@ -7,14 +7,7 @@
     {
         <div class="tile-row explorer-item" data-type="@item.Type" data-id="@item.Id" data-name="@item.Name">
             <div class="tile-icon">
-                @if (item.Type == "folder")
-                {
-                    <i class="bi bi-folder"></i>
-                }
-                else
-                {
-                    @Html.Raw(GetFileIcon(item.Extension))
-                }
+                <img src="~/images/file-icons/@(item.IconName).svg" class="file-icon" alt="" />
                 @if (item.IsNetworkAvailable)
                 {
                     <i class="bi bi-cloud-check network-icon"></i>
@@ -42,24 +35,6 @@ else
 }
 
 @functions {
-    private string GetFileIcon(string? extension)
-    {
-        var ext = extension?.ToLowerInvariant();
-        return ext switch
-        {
-            ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" or ".svg" => "<i class='bi bi-file-earmark-image'></i>",
-            ".pdf" => "<i class='bi bi-file-earmark-pdf'></i>",
-            ".zip" or ".rar" or ".7z" => "<i class='bi bi-file-earmark-zip'></i>",
-            ".mp3" or ".wav" or ".flac" => "<i class='bi bi-file-earmark-music'></i>",
-            ".mp4" or ".avi" or ".mov" or ".mkv" => "<i class='bi bi-file-earmark-play'></i>",
-            ".doc" or ".docx" => "<i class='bi bi-file-earmark-word'></i>",
-            ".xls" or ".xlsx" => "<i class='bi bi-file-earmark-excel'></i>",
-            ".ppt" or ".pptx" => "<i class='bi bi-file-earmark-ppt'></i>",
-            ".txt" or ".md" => "<i class='bi bi-file-earmark-text'></i>",
-            _ => "<i class='bi bi-file-earmark'></i>"
-        };
-    }
-
     private string FormatSize(long size)
     {
         string[] suffix = { "Б", "КБ", "МБ", "ГБ", "ТБ" };

--- a/FileManager.Web/Pages/Files/_FilesGrid.cshtml
+++ b/FileManager.Web/Pages/Files/_FilesGrid.cshtml
@@ -18,7 +18,7 @@
         {
             <div class="file-card explorer-item" data-type="folder" data-id="@item.Id" data-name="@item.Name">
                 <div class="file-card-icon">
-                    <i class="bi bi-folder"></i>
+                    <img src="~/images/file-icons/@(item.IconName).svg" class="file-icon" alt="" />
                     @if (item.IsNetworkAvailable)
                     {
                         <i class="bi bi-cloud-check network-icon"></i>
@@ -37,7 +37,7 @@
         {
             <div class="file-card explorer-item" data-type="file" data-id="@item.Id" data-name="@item.Name">
                 <div class="file-card-icon">
-                    @Html.Raw(GetFileIcon(item.Extension))
+                    <img src="~/images/file-icons/@(item.IconName).svg" class="file-icon" alt="" />
                     @if (item.IsNetworkAvailable)
                     {
                         <i class="bi bi-cloud-check network-icon"></i>
@@ -92,24 +92,6 @@ else
 </script>
 
 @functions {
-    private string GetFileIcon(string? extension)
-    {
-        var ext = extension?.ToLowerInvariant();
-        return ext switch
-        {
-            ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" or ".svg" => "<i class='bi bi-file-earmark-image'></i>",
-            ".pdf" => "<i class='bi bi-file-earmark-pdf'></i>",
-            ".zip" or ".rar" or ".7z" => "<i class='bi bi-file-earmark-zip'></i>",
-            ".mp3" or ".wav" or ".flac" => "<i class='bi bi-file-earmark-music'></i>",
-            ".mp4" or ".avi" or ".mov" or ".mkv" => "<i class='bi bi-file-earmark-play'></i>",
-            ".doc" or ".docx" => "<i class='bi bi-file-earmark-word'></i>",
-            ".xls" or ".xlsx" => "<i class='bi bi-file-earmark-excel'></i>",
-            ".ppt" or ".pptx" => "<i class='bi bi-file-earmark-ppt'></i>",
-            ".txt" or ".md" => "<i class='bi bi-file-earmark-text'></i>",
-            _ => "<i class='bi bi-file-earmark'></i>"
-        };
-    }
-
     private string FormatSize(long size)
     {
         string[] suffix = { "Б", "КБ", "МБ", "ГБ", "ТБ" };

--- a/FileManager.Web/wwwroot/css/site.css
+++ b/FileManager.Web/wwwroot/css/site.css
@@ -655,7 +655,8 @@ body {
     }
 
 .file-icon {
-    font-size: 18px;
+    width: 24px;
+    height: 24px;
     margin-right: 8px;
 }
 
@@ -1188,7 +1189,8 @@ body {
     }
 
 .file-icon {
-    font-size: 18px;
+    width: 24px;
+    height: 24px;
     margin-right: 8px;
 }
 
@@ -1729,7 +1731,8 @@ body {
     }
 
 .file-icon {
-    font-size: 16px;
+    width: 24px;
+    height: 24px;
     margin-right: 8px;
 }
 

--- a/FileManager.Web/wwwroot/images/file-icons/archive.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/archive.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#6d4c41"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">ZIP</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/audio.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/audio.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#00acc1"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">AUD</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/docx.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/docx.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#1e88e5"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">DOC</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/file.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/file.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#9e9e9e"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">FILE</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/folder.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/folder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#fbc02d"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#000">DIR</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/image.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#8e24aa"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">IMG</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/pdf.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/pdf.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#e53935"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">PDF</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/pptx.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/pptx.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#fb8c00"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">PPT</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/txt.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/txt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#546e7a"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">TXT</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/video.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/video.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#ad1457"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">VID</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/xlsx.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/xlsx.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#43a047"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">XLS</text>
+</svg>


### PR DESCRIPTION
## Summary
- добавлен каталог с SVG-иконками файлов
- в TreeNodeDto реализован выбор названия иконки по расширению
- в представлениях файлов заменены Bootstrap-иконки на SVG-изображения
- в site.css заданы размеры иконок

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6895d7387d448330b735752a58a6cbbf