### PR TITLE
Fix upload modal activation, trash item actions, and style favorites page

### DIFF
--- a/FileManager.Web/Pages/Favorites/Index.cshtml
+++ b/FileManager.Web/Pages/Favorites/Index.cshtml
@@ -5,33 +5,39 @@
     ViewData["Title"] = "Избранное";
 }
 
-<h2>Избранное</h2>
+<div class="container mt-4">
+    <h2 class="mb-4">@ViewData["Title"]</h2>
 
-@if (Model.Favorites.Count == 0)
-{
-    <p>У вас пока нет избранных элементов.</p>
-}
-else
-{
-    <ul class="favorites-list">
-    @foreach (var item in Model.Favorites)
+    @if (Model.Favorites.Count == 0)
     {
-        <li>
-            @if (item.Type == "file")
-            {
-                <i class="bi bi-file-earmark"></i>
-                <a href="/api/files/@item.Id/content">@item.Name</a>
-            }
-            else
-            {
-                <i class="bi bi-folder"></i>
-                <a href="/Files?folderId=@item.Id">@item.Name</a>
-            }
-            <button class="btn btn-link text-danger" title="Удалить из избранного" onclick="removeFavorite('@item.Id','@item.Type')"><i class="bi bi-x"></i></button>
-        </li>
+        <div class="alert alert-info">У вас пока нет избранных элементов.</div>
     }
-    </ul>
-}
+    else
+    {
+        <ul class="list-group">
+        @foreach (var item in Model.Favorites)
+        {
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                    @if (item.Type == "file")
+                    {
+                        <i class="bi bi-file-earmark me-2"></i>
+                        <a href="/api/files/@item.Id/content">@item.Name</a>
+                    }
+                    else
+                    {
+                        <i class="bi bi-folder me-2"></i>
+                        <a href="/Files?folderId=@item.Id">@item.Name</a>
+                    }
+                </div>
+                <button class="btn btn-sm btn-outline-danger" title="Удалить из избранного" onclick="removeFavorite('@item.Id','@item.Type')">
+                    <i class="bi bi-x-lg"></i>
+                </button>
+            </li>
+        }
+        </ul>
+    }
+</div>
 
 @section Scripts {
 <script>

--- a/FileManager.Web/Pages/Files/_UploadModal.cshtml
+++ b/FileManager.Web/Pages/Files/_UploadModal.cshtml
@@ -97,6 +97,7 @@
                 if (selectedId) {
                     document.getElementById('uploadFolderSelect').value = selectedId;
                 }
+                updateUploadButtonState();
             }
         } catch (error) {
             console.error('Error loading folders:', error);
@@ -128,6 +129,9 @@
     document.getElementById('fileInput').addEventListener('change', function(e) {
         handleFiles(Array.from(e.target.files));
     });
+
+    // Изменение выбранной папки
+    document.getElementById('uploadFolderSelect').addEventListener('change', updateUploadButtonState);
 
     // Drag & Drop обработчики
     const dropZone = document.getElementById('dropZone');
@@ -161,7 +165,6 @@
             // Показываем список файлов и комментарий
             document.getElementById('filesList').style.display = 'block';
             document.getElementById('commentGroup').style.display = 'block';
-            document.getElementById('uploadBtn').disabled = false;
 
             // Валидируем файлы
             await validateFiles(files);
@@ -169,6 +172,8 @@
             // Отображаем файлы
             displaySelectedFiles(files);
         }
+
+        updateUploadButtonState();
     }
 
     // Валидация файлов
@@ -243,8 +248,9 @@
         if (selectedFiles.length === 0) {
             document.getElementById('filesList').style.display = 'none';
             document.getElementById('commentGroup').style.display = 'none';
-            document.getElementById('uploadBtn').disabled = true;
         }
+
+        updateUploadButtonState();
     }
 
     // Начало загрузки
@@ -384,7 +390,7 @@
     // Отображение ошибки загрузки
     function showUploadError(message) {
         document.getElementById('uploadProgress').style.display = 'none';
-        document.getElementById('uploadBtn').disabled = false;
+        updateUploadButtonState();
 
         const resultsContainer = document.getElementById('uploadResults');
         resultsContainer.style.display = 'block';
@@ -405,7 +411,15 @@
         document.getElementById('commentGroup').style.display = 'none';
         document.getElementById('uploadProgress').style.display = 'none';
         document.getElementById('uploadResults').style.display = 'none';
-        document.getElementById('uploadBtn').disabled = true;
+        updateUploadButtonState();
+    }
+
+    // Состояние кнопки загрузки
+    function updateUploadButtonState() {
+        const hasFiles = selectedFiles.length > 0;
+        const folderSelected = document.getElementById('uploadFolderSelect').value;
+        const btn = document.getElementById('uploadBtn');
+        btn.disabled = !(hasFiles && folderSelected);
     }
 
     // Форматирование размера файла

--- a/FileManager.Web/Pages/Trash/Index.cshtml
+++ b/FileManager.Web/Pages/Trash/Index.cshtml
@@ -24,8 +24,8 @@
             <td>@(item.Type == "file" ? "Файл" : "Папка")</td>
             <td>@item.DeletedAt?.ToLocalTime().ToString("g")</td>
             <td>
-                <button class="btn btn-sm btn-success" onclick="restore('@item.Id','@item.Type')">Восстановить</button>
-                <button class="btn btn-sm btn-danger" onclick="remove('@item.Id','@item.Type')">Удалить</button>
+                <button class="btn btn-sm btn-success" onclick="restoreItem('@item.Id','@item.Type')">Восстановить</button>
+                <button class="btn btn-sm btn-danger" onclick="deleteItem('@item.Id','@item.Type')">Удалить</button>
             </td>
         </tr>
     }
@@ -34,16 +34,25 @@
 
 @section Scripts {
 <script>
-async function restore(id,type){
-    const url = type==='file'? `/api/trash/restore/file/${id}` : `/api/trash/restore/folder/${id}`;
-    const res = await fetch(url,{method:'POST'});
-    if(res.ok) location.reload();
+async function restoreItem(id, type) {
+    const url = type === 'file' ? `/api/trash/restore/file/${id}` : `/api/trash/restore/folder/${id}`;
+    const res = await fetch(url, { method: 'POST', credentials: 'include' });
+    if (res.ok) {
+        location.reload();
+    } else {
+        alert('Не удалось восстановить объект');
+    }
 }
-async function remove(id,type){
-    if(!confirm('Удалить окончательно?')) return;
-    const url = type==='file'? `/api/trash/file/${id}` : `/api/trash/folder/${id}`;
-    const res = await fetch(url,{method:'DELETE'});
-    if(res.ok) location.reload();
+
+async function deleteItem(id, type) {
+    if (!confirm('Удалить окончательно?')) return;
+    const url = type === 'file' ? `/api/trash/file/${id}` : `/api/trash/folder/${id}`;
+    const res = await fetch(url, { method: 'DELETE', credentials: 'include' });
+    if (res.ok) {
+        location.reload();
+    } else {
+        alert('Не удалось удалить объект');
+    }
 }
 </script>
 }


### PR DESCRIPTION
## Summary
- ensure upload button activates only when a folder and files are selected
- centralize upload button state management for file modal
- fix trash restore/delete handlers with credentialed requests and error feedback
- style favorites list with Bootstrap components and removal buttons

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689988d4f1608330ac95a080558c0936