### PR TITLE
Включение куки и CSRF в запросах

### DIFF
--- a/FileManager.Web/Pages/Files/_UploadModal.cshtml
+++ b/FileManager.Web/Pages/Files/_UploadModal.cshtml
@@ -1,4 +1,5 @@
 ﻿<div id="uploadModal" class="modal modal-exit" style="display: none;">
+    @Html.AntiForgeryToken()
     <div class="modal-content">
         <div class="modal-header">
             <h3>Загрузка файлов</h3>
@@ -94,13 +95,17 @@
             if (response.ok) {
                 availableFolders = await response.json();
                 populateFoldersSelect();
-                if (selectedId) {
-                    document.getElementById('uploadFolderSelect').value = selectedId;
+                const select = document.getElementById('uploadFolderSelect');
+                if (selectedId && [...select.options].some(o => o.value === selectedId)) {
+                    select.value = selectedId;
+                } else if (select.options.length > 1) {
+                    select.selectedIndex = 1;
                 }
-                updateUploadButtonState();
             }
         } catch (error) {
             console.error('Error loading folders:', error);
+        } finally {
+            updateUploadButtonState();
         }
     }
 
@@ -161,19 +166,25 @@
     async function handleFiles(files) {
         selectedFiles = files;
 
+        // Обновляем состояние кнопки сразу, чтобы разблокировать загрузку
+        updateUploadButtonState();
+
         if (files.length > 0) {
             // Показываем список файлов и комментарий
             document.getElementById('filesList').style.display = 'block';
             document.getElementById('commentGroup').style.display = 'block';
 
-            // Валидируем файлы
-            await validateFiles(files);
+            try {
+                // Валидируем файлы
+                await validateFiles(files);
 
-            // Отображаем файлы
-            displaySelectedFiles(files);
+                // Отображаем файлы
+                displaySelectedFiles(files);
+            } finally {
+                // Повторно проверяем доступность кнопки
+                updateUploadButtonState();
+            }
         }
-
-        updateUploadButtonState();
     }
 
     // Валидация файлов
@@ -286,6 +297,10 @@
             const xhr = new XMLHttpRequest();
             xhr.open('POST', '/api/upload');
             xhr.withCredentials = true;
+            const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value;
+            if (token) {
+                xhr.setRequestHeader('RequestVerificationToken', token);
+            }
 
             xhr.upload.onprogress = function (e) {
                 if (e.lengthComputable) {
@@ -385,6 +400,7 @@
             ${successCount > 0 ? '<button class="btn btn-primary" onclick="reloadPage()">Обновить страницу</button>' : ''}
         `;
         resultsContainer.appendChild(summary);
+        updateUploadButtonState();
     }
 
     // Отображение ошибки загрузки
@@ -407,6 +423,8 @@
         selectedFiles = [];
         document.getElementById('fileInput').value = '';
         document.getElementById('uploadComment').value = '';
+        const folderSelect = document.getElementById('uploadFolderSelect');
+        folderSelect.innerHTML = '<option value="" disabled selected>Выберите папку</option>';
         document.getElementById('filesList').style.display = 'none';
         document.getElementById('commentGroup').style.display = 'none';
         document.getElementById('uploadProgress').style.display = 'none';

--- a/FileManager.Web/Program.cs
+++ b/FileManager.Web/Program.cs
@@ -4,6 +4,7 @@ using FileManager.Application.Services;
 using FileManager.Web.Middleware;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http.Features;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -46,6 +47,10 @@ builder.Services.AddControllers();
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddLogging();
+builder.Services.Configure<FormOptions>(o =>
+{
+    o.MultipartBodyLengthLimit = 1024L * 1024 * 1024; // 1 ГБ
+});
 
 var app = builder.Build();
 

--- a/FileManager.Web/wwwroot/js/site.js
+++ b/FileManager.Web/wwwroot/js/site.js
@@ -1,3 +1,15 @@
+const originalFetch = window.fetch;
+window.fetch = (input, init = {}) => {
+    init = init || {};
+    init.credentials = init.credentials || 'include';
+    init.headers = init.headers || {};
+    const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value;
+    if (token && !init.headers['RequestVerificationToken']) {
+        init.headers['RequestVerificationToken'] = token;
+    }
+    return originalFetch(input, init);
+};
+
 let mainContainer;
 let isLoading = false;
 


### PR DESCRIPTION
## Summary
- добавлен глобальный перехват fetch для отправки cookie и RequestVerificationToken
- в модалке загрузки файлов рендерится Anti-Forgery токен и XHR передает его на сервер
- увеличен лимит multipart-запроса до 1 ГБ
- после выбора файлов кнопка загрузки активируется сразу и повторно проверяется после валидации
- при открытии модалки автоматически выбирается первая папка и состояние кнопки пересчитывается

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68999efdd18883309d7a93ffe899bb82