### PR TITLE
Add timeout handling for file validation and upload

### DIFF
--- a/FileManager.Web/Pages/Files/_UploadModal.cshtml
+++ b/FileManager.Web/Pages/Files/_UploadModal.cshtml
@@ -223,15 +223,18 @@
         files.forEach(file => formData.append('files', file));
         const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value;
         const headers = token ? { 'RequestVerificationToken': token } : {};
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 30000);
 
         try {
             const response = await fetch('/api/upload/validate', {
                 method: 'POST',
                 body: formData,
                 credentials: 'include',
-                headers
+                headers,
+                signal: controller.signal
             });
-
+            clearTimeout(timeoutId);
 
             const contentType = response.headers.get('content-type') || '';
             if (response.ok && contentType.includes('application/json')) {
@@ -239,10 +242,13 @@
                 updateFileValidationResults(data.results);
             } else {
                 showUploadError(`Сервер вернул не-JSON/HTML (статус ${response.status})`);
-
             }
         } catch (error) {
-            showUploadError('Ошибка проверки файлов');
+            if (error.name === 'AbortError') {
+                showUploadError('Время ожидания истекло, попробуйте ещё раз');
+            } else {
+                showUploadError('Ошибка проверки файлов');
+            }
         }
     }
 
@@ -330,6 +336,7 @@
             xhr.open('POST', '/api/upload');
             xhr.responseType = 'json';
             xhr.withCredentials = true;
+            xhr.timeout = 30000;
             const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value;
             if (token) {
                 xhr.setRequestHeader('RequestVerificationToken', token);
@@ -399,6 +406,10 @@
                     statusText.classList.add('status-error');
                 }
                 uploadNext(index + 1);
+            };
+
+            xhr.ontimeout = function () {
+                showUploadError('Время ожидания истекло, попробуйте ещё раз');
             };
 
             xhr.send(formData);


### PR DESCRIPTION
## Summary
- add 30s AbortController timeout to file validation
- cancel upload request after 30s and notify user

## Testing
- `dotnet build FileManager.Web.sln`

------
https://chatgpt.com/codex/tasks/task_e_6899e40a4ac083309597599d9cab3346