### PR TITLE
Обновление CSRF-токена при загрузке файлов

### DIFF
--- a/FileManager.Web/Pages/Files/_UploadModal.cshtml
+++ b/FileManager.Web/Pages/Files/_UploadModal.cshtml
@@ -221,7 +221,7 @@
         if (!await refreshCsrfToken()) return;
         const formData = new FormData();
         files.forEach(file => formData.append('files', file));
-        const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value;
+        const token = document.querySelector('#uploadModal input[name="__RequestVerificationToken"]')?.value;
         const headers = token ? { 'RequestVerificationToken': token } : {};
 
         try {
@@ -304,7 +304,6 @@
 
     // Начало загрузки
     async function startUpload() {
-        if (!await refreshCsrfToken()) return;
         const folderId = document.getElementById('uploadFolderSelect').value;
         const comment = document.getElementById('uploadComment').value;
 
@@ -314,9 +313,14 @@
         const totalFiles = selectedFiles.length;
         const results = [];
 
-        function uploadNext(index) {
+        async function uploadNext(index) {
             if (index >= totalFiles) {
                 showUploadResults(results);
+                return;
+            }
+
+            if (!await refreshCsrfToken()) {
+                showUploadError('Не удалось обновить токен безопасности. Пожалуйста, перезагрузите страницу.');
                 return;
             }
 
@@ -330,7 +334,7 @@
             xhr.open('POST', '/api/upload');
             xhr.responseType = 'json';
             xhr.withCredentials = true;
-            const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value;
+            const token = document.querySelector('#uploadModal input[name="__RequestVerificationToken"]')?.value;
             if (token) {
                 xhr.setRequestHeader('RequestVerificationToken', token);
             }


### PR DESCRIPTION
## Summary
- Обновлено получение анти-CSRF токена из модального окна при валидации и загрузке
- Перед каждой отправкой запросов выполняется обновление токена и куки

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6899e63383f4833082cf6fcf8bbf4205