### PR TITLE
refactor: unify upload modal CSRF token

### DIFF
--- a/FileManager.Web/Pages/Files/_UploadModal.cshtml
+++ b/FileManager.Web/Pages/Files/_UploadModal.cshtml
@@ -81,6 +81,10 @@
         return false;
     }
 
+    function getUploadModalToken() {
+        return document.querySelector('#uploadModal input[name="__RequestVerificationToken"]')?.value;
+    }
+
 
     // Открытие модального окна
     async function openUploadModal(folderId = null) {
@@ -221,7 +225,7 @@
         if (!await refreshCsrfToken()) return;
         const formData = new FormData();
         files.forEach(file => formData.append('files', file));
-        const token = document.querySelector('#uploadModal input[name="__RequestVerificationToken"]')?.value;
+        const token = getUploadModalToken();
         const headers = token ? { 'RequestVerificationToken': token } : {};
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 30000);
@@ -341,7 +345,7 @@
             xhr.responseType = 'json';
             xhr.withCredentials = true;
 
-            const token = document.querySelector('#uploadModal input[name="__RequestVerificationToken"]')?.value;
+            const token = getUploadModalToken();
 
             if (token) {
                 xhr.setRequestHeader('RequestVerificationToken', token);


### PR DESCRIPTION
## Summary
- centralize CSRF token access in upload modal
- use shared token retrieval in validation and upload functions

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689ad8f878e083309c4627c7b82d0b67