### PR TITLE
feat: add upload page

### DIFF
--- a/FileManager.Web/Pages/Files/Index.cshtml
+++ b/FileManager.Web/Pages/Files/Index.cshtml
@@ -31,7 +31,7 @@
     }
 
     <div class="action-bar">
-        <button type="button" id="btnUpload" class="btn btn-primary btn-sm"><i class="bi bi-upload"></i> Загрузить</button>
+        <a asp-page="Upload" class="btn btn-primary btn-sm"><i class="bi bi-upload"></i> Загрузить файлы</a>
         <button type="button" id="btnCreateFolder" class="btn btn-primary btn-sm"><i class="bi bi-folder-plus"></i> Создать папку</button>
         <button type="button" id="btnManageAccess" class="btn btn-primary btn-sm"><i class="bi bi-shield-lock"></i> Управление доступом</button>
     </div>
@@ -68,7 +68,6 @@
 </div>
 
 @await Html.PartialAsync("_FolderModals")
-@await Html.PartialAsync("_UploadModal")
 @await Html.PartialAsync("_AccessModal")
 @await Html.PartialAsync("_PropertiesModal")
 <div id="contextMenu" class="context-menu">

--- a/FileManager.Web/Pages/Files/Upload.cshtml
+++ b/FileManager.Web/Pages/Files/Upload.cshtml
@@ -1,3 +1,462 @@
-﻿@page
+@page
+@model FileManager.Web.Pages.Files.UploadModel
+@using System.Text.Json
 @{
+    ViewData["Title"] = "Загрузка файлов";
+    var foldersJson = JsonSerializer.Serialize(Model.Folders,
+        new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 }
+
+<form id="uploadForm" method="post" enctype="multipart/form-data">
+    @Html.AntiForgeryToken()
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3>Загрузка файлов</h3>
+        </div>
+
+        <div class="modal-body">
+            <!-- Выбор папки -->
+            <div class="form-group">
+                <label for="uploadFolderSelect">Папка назначения:</label>
+                <select id="uploadFolderSelect" class="form-select">
+                    <option value="" disabled selected>Выберите папку</option>
+                </select>
+            </div>
+
+            <!-- Выбор файлов -->
+            <div id="dropZone" class="drop-zone">
+                <div class="drop-zone-content">
+                    <p>Перетащите файлы сюда или выберите их через форму ниже</p>
+                    <input type="file" id="fileInput" class="form-control" multiple />
+                </div>
+            </div>
+
+            <!-- Список выбранных файлов -->
+            <div id="filesList" class="files-list" style="display: none;">
+                <h4>Выбранные файлы:</h4>
+                <div id="filesContainer"></div>
+            </div>
+
+            <!-- Комментарий -->
+            <div class="form-group" id="commentGroup" style="display: none;">
+                <label for="uploadComment">Комментарий к загрузке:</label>
+                <textarea id="uploadComment" class="form-textarea" placeholder="Опишите что изменено или почему загружается..."></textarea>
+            </div>
+
+            <!-- Прогресс загрузки -->
+            <div id="uploadProgress" class="upload-progress" style="display: none;">
+                <div class="progress-bar">
+                    <div id="progressFill" class="progress-fill"></div>
+                </div>
+                <div id="progressText" class="progress-text">0%</div>
+            </div>
+
+            <!-- Результаты загрузки -->
+            <div id="uploadResults" class="upload-results" style="display: none;"></div>
+        </div>
+
+        <div class="modal-footer">
+            <a asp-page="Index" class="btn btn-secondary">Отмена</a>
+            <button type="button" id="uploadBtn" class="btn btn-primary" onclick="startUpload()">
+                Загрузить файлы
+            </button>
+        </div>
+    </div>
+</form>
+
+<script>
+    var selectedFiles = [];
+    var availableFolders = @Html.Raw(foldersJson);
+
+    document.addEventListener('DOMContentLoaded', async function () {
+        await refreshCsrfToken();
+        loadAvailableFolders('@Model.FolderId');
+    });
+
+    async function refreshCsrfToken() {
+        try {
+            const response = await fetch('/api/upload/token', { credentials: 'include' });
+            if (response.ok) {
+                const data = await response.json();
+                const input = document.querySelector('input[name="__RequestVerificationToken"]');
+                if (input && data.token) {
+                    input.value = data.token;
+                    return true;
+                }
+            }
+            showUploadError('Не удалось обновить токен безопасности. Пожалуйста, перезагрузите страницу.');
+        } catch (err) {
+            console.error('Token refresh error:', err);
+            showUploadError('Не удалось обновить токен безопасности. Пожалуйста, перезагрузите страницу.');
+        }
+        return false;
+    }
+
+    function getUploadModalToken() {
+        return document.querySelector('input[name="__RequestVerificationToken"]')?.value;
+    }
+
+    function loadAvailableFolders(selectedId = null) {
+        populateFoldersSelect(availableFolders);
+        const select = document.getElementById('uploadFolderSelect');
+        if (selectedId && [...select.options].some(o => o.value === selectedId)) {
+            select.value = selectedId;
+        } else if (select.options.length > 1) {
+            select.selectedIndex = 1;
+        }
+        updateUploadButtonState();
+    }
+
+    function populateFoldersSelect(folders = availableFolders) {
+        const select = document.getElementById('uploadFolderSelect');
+        select.innerHTML = '<option value="" disabled>Выберите папку</option>';
+
+        function addFolderOptions(items, level = 0) {
+            items.forEach(folder => {
+                const option = document.createElement('option');
+                option.value = folder.id;
+                option.textContent = '  '.repeat(level) + folder.name;
+                select.appendChild(option);
+
+                if (folder.children && folder.children.length > 0) {
+                    addFolderOptions(folder.children.filter(child => child.type === 'folder'), level + 1);
+                }
+            });
+        }
+
+        addFolderOptions(folders);
+    }
+
+    document.getElementById('fileInput').addEventListener('change', function (e) {
+        handleFiles(Array.from(e.target.files));
+    });
+
+    document.getElementById('uploadFolderSelect').addEventListener('change', updateUploadButtonState);
+
+    const dropZone = document.getElementById('dropZone');
+
+    dropZone.addEventListener('dragover', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        dropZone.classList.add('drag-over');
+    });
+
+    dropZone.addEventListener('dragleave', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        dropZone.classList.remove('drag-over');
+    });
+
+    dropZone.addEventListener('drop', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        dropZone.classList.remove('drag-over');
+
+        const files = Array.from(e.dataTransfer.files);
+        handleFiles(files);
+    });
+
+    async function handleFiles(files) {
+        selectedFiles = files;
+
+        updateUploadButtonState();
+
+        if (files.length > 0) {
+            document.getElementById('filesList').style.display = 'block';
+            document.getElementById('commentGroup').style.display = 'block';
+
+            try {
+                await validateFiles(files);
+                displaySelectedFiles(files);
+            } finally {
+                updateUploadButtonState();
+            }
+        }
+    }
+
+    async function validateFiles(files) {
+        if (!await refreshCsrfToken()) return;
+        const formData = new FormData();
+        files.forEach(file => formData.append('files', file));
+        const token = getUploadModalToken();
+        const headers = token ? { 'RequestVerificationToken': token } : {};
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 30000);
+
+        try {
+            const response = await fetch('/api/upload/validate', {
+                method: 'POST',
+                body: formData,
+                credentials: 'include',
+                headers,
+                signal: controller.signal
+            });
+            clearTimeout(timeoutId);
+
+            const contentType = response.headers.get('content-type') || '';
+            if (response.ok && contentType.includes('application/json')) {
+                const data = await response.json();
+                updateFileValidationResults(data.results);
+            } else {
+                showUploadError(`Сервер вернул не-JSON/HTML (статус ${response.status})`);
+            }
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                showUploadError('Время ожидания истекло, попробуйте ещё раз');
+            } else {
+                showUploadError('Ошибка проверки файлов');
+            }
+        }
+    }
+
+    function displaySelectedFiles(files) {
+        const container = document.getElementById('filesContainer');
+        container.innerHTML = '';
+
+        files.forEach((file, index) => {
+            const fileItem = document.createElement('div');
+            fileItem.className = 'file-item';
+            fileItem.innerHTML = `
+                <div class="file-info">
+                    <span class="file-name">${file.name}</span>
+                    <span class="file-size">${formatFileSize(file.size)}</span>
+                </div>
+                <div class="file-status" id="status-${index}">
+                    <div class="progress-bar"><div class="progress-fill" id="progress-${index}"></div></div>
+                    <span class="status-text" id="status-text-${index}">Готов к загрузке</span>
+                </div>
+                <button type="button" class="btn btn-danger btn-sm" onclick="removeFile(${index})">
+                    Удалить
+                </button>
+            `;
+            container.appendChild(fileItem);
+        });
+    }
+
+    function updateFileValidationResults(results) {
+        results.forEach((result, index) => {
+            const statusText = document.getElementById(`status-text-${index}`);
+            if (statusText) {
+                statusText.className = 'status-text';
+                if (!result.isValid) {
+                    statusText.textContent = `Ошибка: ${result.errors.join(', ')}`;
+                    statusText.classList.add('status-error');
+                    statusText.closest('.file-item')?.classList.add('file-invalid');
+                } else if (result.warnings.length > 0) {
+                    statusText.textContent = `Предупреждение: ${result.warnings.join(', ')}`;
+                    statusText.classList.add('status-warning');
+                }
+            }
+        });
+    }
+
+    function removeFile(index) {
+        selectedFiles.splice(index, 1);
+        displaySelectedFiles(selectedFiles);
+
+        if (selectedFiles.length === 0) {
+            document.getElementById('filesList').style.display = 'none';
+            document.getElementById('commentGroup').style.display = 'none';
+        }
+
+        updateUploadButtonState();
+    }
+
+    async function startUpload() {
+        const folderId = document.getElementById('uploadFolderSelect').value;
+        const comment = document.getElementById('uploadComment').value;
+
+        document.getElementById('uploadProgress').style.display = 'block';
+        document.getElementById('uploadBtn').disabled = true;
+
+        const totalFiles = selectedFiles.length;
+        const results = [];
+
+        async function uploadNext(index) {
+            if (index >= totalFiles) {
+                showUploadResults(results);
+                return;
+            }
+
+            if (!await refreshCsrfToken()) {
+                showUploadError('Не удалось обновить токен безопасности. Пожалуйста, перезагрузите страницу.');
+                return;
+            }
+
+            const file = selectedFiles[index];
+            const formData = new FormData();
+            formData.append('files', file);
+            formData.append('folderId', folderId);
+            if (comment) formData.append('comment', comment);
+
+            const xhr = new XMLHttpRequest();
+            xhr.open('POST', '/api/upload');
+            xhr.responseType = 'json';
+            xhr.withCredentials = true;
+
+            const token = getUploadModalToken();
+
+            if (token) {
+                xhr.setRequestHeader('RequestVerificationToken', token);
+            }
+
+            xhr.upload.onprogress = function (e) {
+                if (e.lengthComputable) {
+                    const percent = Math.round((e.loaded / e.total) * 100);
+                    const progressEl = document.getElementById(`progress-${index}`);
+                    const statusText = document.getElementById(`status-text-${index}`);
+                    if (progressEl) progressEl.style.width = percent + '%';
+                    if (statusText) statusText.textContent = percent + '%';
+
+                    const overall = Math.round(((index + e.loaded / e.total) / totalFiles) * 100);
+                    document.getElementById('progressFill').style.width = overall + '%';
+                    document.getElementById('progressText').textContent = overall + '%';
+                }
+            };
+
+            xhr.onload = function () {
+                const progressEl = document.getElementById(`progress-${index}`);
+                const statusText = document.getElementById(`status-text-${index}`);
+                if (progressEl) progressEl.style.width = '100%';
+
+                const isJson = xhr.getResponseHeader('content-type')?.includes('application/json');
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    const response = xhr.response;
+
+                    if (isJson && response && response.results) {
+
+                        const result = response.results[0];
+                        results.push(result);
+                        if (statusText) {
+                            statusText.textContent = result.success ? 'Готово' : result.error;
+                            if (!result.success) statusText.classList.add('status-error');
+                        }
+                    } else {
+
+                        const error = isJson ? 'Некорректный ответ сервера' : `Сервер вернул не-JSON/HTML (статус ${xhr.status})`;
+
+                        results.push({ success: false, fileName: file.name, error });
+                        if (statusText) {
+                            statusText.textContent = error;
+                            statusText.classList.add('status-error');
+                        }
+                    }
+                } else {
+                    const error = `Ошибка ${xhr.status}`;
+                    results.push({ success: false, fileName: file.name, error });
+                    if (statusText) {
+                        statusText.textContent = error;
+                        statusText.classList.add('status-error');
+                    }
+                }
+
+                uploadNext(index + 1);
+            };
+
+            xhr.onerror = function () {
+                const statusText = document.getElementById(`status-text-${index}`);
+                const progressEl = document.getElementById(`progress-${index}`);
+                if (progressEl) progressEl.style.width = '100%';
+                const error = 'Ошибка соединения';
+                results.push({ success: false, fileName: file.name, error });
+                if (statusText) {
+                    statusText.textContent = error;
+                    statusText.classList.add('status-error');
+                }
+                uploadNext(index + 1);
+            };
+
+            xhr.ontimeout = function () {
+                showUploadError('Время ожидания истекло, попробуйте ещё раз');
+            };
+
+            xhr.send(formData);
+        }
+
+        uploadNext(0);
+    }
+
+    function showUploadResults(results) {
+        document.getElementById('uploadProgress').style.display = 'none';
+
+        const resultsContainer = document.getElementById('uploadResults');
+        resultsContainer.style.display = 'block';
+        resultsContainer.innerHTML = '<h4>Результаты загрузки:</h4>';
+
+        let successCount = 0;
+        let errorCount = 0;
+
+        results.forEach(result => {
+            const resultItem = document.createElement('div');
+            resultItem.className = `result-item ${result.success ? 'success' : 'error'}`;
+
+            if (result.success) {
+                successCount++;
+                resultItem.innerHTML = `
+                    <span class="result-icon">✅</span>
+                    <span class="result-text">${result.fileName} - загружен успешно</span>
+                `;
+            } else {
+                errorCount++;
+                resultItem.innerHTML = `
+                    <span class="result-icon">❌</span>
+                    <span class="result-text">${result.fileName} - ${result.error}</span>
+                `;
+            }
+
+            resultsContainer.appendChild(resultItem);
+        });
+
+        const summary = document.createElement('div');
+        summary.className = 'upload-summary';
+        summary.innerHTML = `
+            <p><strong>Итого:</strong> ${successCount} успешно, ${errorCount} с ошибками</p>
+        `;
+        resultsContainer.appendChild(summary);
+
+        reloadPage();
+    }
+
+    function showUploadError(message) {
+        document.getElementById('uploadProgress').style.display = 'none';
+        updateUploadButtonState();
+
+        const resultsContainer = document.getElementById('uploadResults');
+        resultsContainer.style.display = 'block';
+        resultsContainer.innerHTML = `
+            <div class="result-item error">
+                <span class="result-icon">❌</span>
+                <span class="result-text">${message}</span>
+            </div>
+        `;
+    }
+
+    function resetUploadForm() {
+        selectedFiles = [];
+        document.getElementById('fileInput').value = '';
+        document.getElementById('uploadComment').value = '';
+        const folderSelect = document.getElementById('uploadFolderSelect');
+        folderSelect.innerHTML = '<option value="" disabled selected>Выберите папку</option>';
+        document.getElementById('filesList').style.display = 'none';
+        document.getElementById('commentGroup').style.display = 'none';
+        document.getElementById('uploadProgress').style.display = 'none';
+        document.getElementById('uploadResults').style.display = 'none';
+        updateUploadButtonState();
+    }
+
+    function updateUploadButtonState() {
+        const btn = document.getElementById('uploadBtn');
+        btn.disabled = false;
+    }
+
+    function formatFileSize(bytes) {
+        if (bytes < 1024) return bytes + ' Б';
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' КБ';
+        if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' МБ';
+        return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' ГБ';
+    }
+
+    function reloadPage() {
+        window.location.href = '/Files';
+    }
+</script>

--- a/FileManager.Web/Pages/Files/Upload.cshtml.cs
+++ b/FileManager.Web/Pages/Files/Upload.cshtml.cs
@@ -1,0 +1,57 @@
+using FileManager.Application.DTOs;
+using FileManager.Application.Interfaces;
+using FileManager.Application.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Security.Claims;
+
+namespace FileManager.Web.Pages.Files;
+
+[Authorize]
+public class UploadModel : PageModel
+{
+    private readonly IFolderService _folderService;
+    private readonly FileUploadService _fileUploadService;
+
+    public UploadModel(IFolderService folderService, FileUploadService fileUploadService)
+    {
+        _folderService = folderService;
+        _fileUploadService = fileUploadService;
+    }
+
+    [BindProperty(SupportsGet = true)]
+    public Guid FolderId { get; set; }
+
+    [BindProperty]
+    public List<IFormFile> Files { get; set; } = new();
+
+    [BindProperty]
+    public string? Comment { get; set; }
+
+    public List<TreeNodeDto> Folders { get; set; } = new();
+
+    public async Task OnGet()
+    {
+        var userId = GetCurrentUserId();
+        var isAdmin = User.FindFirst("IsAdmin")?.Value == "True";
+        Folders = await _folderService.GetTreeStructureAsync(userId, isAdmin);
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var userId = GetCurrentUserId();
+        foreach (var file in Files)
+        {
+            await _fileUploadService.UploadFileAsync(file, userId, FolderId, Comment);
+        }
+        return RedirectToPage("Index");
+    }
+
+    private Guid GetCurrentUserId()
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(userIdClaim, out var userId) ? userId : Guid.Empty;
+    }
+}

--- a/FileManager.Web/wwwroot/js/files-manager.js
+++ b/FileManager.Web/wwwroot/js/files-manager.js
@@ -745,10 +745,14 @@ function initializeFilesManager() {
 document.addEventListener('DOMContentLoaded', initializeFilesManager);
 
 
-// Upload modal functions (will be loaded from _UploadModal.cshtml)
-// These are just declarations to avoid errors
-window.openUploadModal = window.openUploadModal || function (folderId) {
-    console.log('Upload modal not loaded yet');
+// Open upload page
+window.openUploadModal = function (folderId) {
+    const url = folderId ? `/Files/Upload?folderId=${folderId}` : '/Files/Upload';
+    if (typeof loadPage === 'function') {
+        loadPage(url);
+    } else {
+        window.location.href = url;
+    }
 };
 
 // Drag and drop for the main page


### PR DESCRIPTION
## Summary
- add standalone upload page with server-side handlers
- link from file list to new upload page and redirect helper
- expose upload page via files-manager

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689adeb7ecb88330833640b1d7b4ed96