### PR TITLE
feat: restore file search filters

### DIFF
--- a/FileManager.Application/Services/FileService.cs
+++ b/FileManager.Application/Services/FileService.cs
@@ -111,18 +111,18 @@ public class FileService : IFileService
     public async Task<SearchResultDto<FileDto>> SearchFilesAsync(SearchRequestDto request, Guid userId, bool isAdmin = false)
     {
         var files = await _filesRepository.SearchAsync(
-            request.SearchTerm,
-            request.FolderId,
-            request.FileType,
-            request.Extension,
-            request.DateFrom,
-            request.DateTo,
-            request.OwnerId,
-            request.Tags,
-            request.UpdatedFrom,
-            request.UpdatedTo,
-            request.MinSizeBytes,
-            request.MaxSizeBytes);
+            searchTerm: request.SearchTerm,
+            folderId: request.FolderId,
+            fileType: request.FileType,
+            extension: request.Extension,
+            dateFrom: request.DateFrom,
+            dateTo: request.DateTo,
+            userId: request.OwnerId,
+            tags: request.Tags,
+            updatedFrom: request.UpdatedFrom,
+            updatedTo: request.UpdatedTo,
+            minSizeBytes: request.MinSizeBytes,
+            maxSizeBytes: request.MaxSizeBytes);
 
         var user = await _userRepository.GetByIdAsync(userId);
 

--- a/FileManager.Web/Pages/Files/Index.cshtml
+++ b/FileManager.Web/Pages/Files/Index.cshtml
@@ -36,10 +36,54 @@
         <button type="button" id="btnManageAccess" class="btn btn-primary btn-sm"><i class="bi bi-shield-lock"></i> Управление доступом</button>
     </div>
 
-    <!-- Поиск и фильтры удалены -->
+    <!-- Панель поиска и фильтров -->
+    <form method="get" class="search-panel">
+        <input type="hidden" name="folderId" value="@Model.CurrentFolderId" />
+        <div class="row g-2 align-items-end">
+            <div class="col-md-3">
+                <label asp-for="SearchRequest.SearchTerm" class="form-label">Поиск</label>
+                <input asp-for="SearchRequest.SearchTerm" class="form-control" placeholder="Введите текст" />
+            </div>
+            <div class="col-md-2">
+                <label asp-for="SearchRequest.FileType" class="form-label">Тип файла</label>
+                <select asp-for="SearchRequest.FileType" class="form-select">
+                    <option value="">Все</option>
+                    @foreach (var type in Enum.GetValues(typeof(FileType)))
+                    {
+                        <option value="@type" selected="@(Model.SearchRequest.FileType == (FileType)type ? "selected" : null)">@type</option>
+                    }
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label asp-for="SearchRequest.DateFrom" class="form-label">Дата с</label>
+                <input asp-for="SearchRequest.DateFrom" type="date" class="form-control" />
+            </div>
+            <div class="col-md-2">
+                <label asp-for="SearchRequest.DateTo" class="form-label">Дата по</label>
+                <input asp-for="SearchRequest.DateTo" type="date" class="form-control" />
+            </div>
+            <div class="col-md-1">
+                <label asp-for="SearchRequest.MinSizeBytes" class="form-label">Мин. размер</label>
+                <input asp-for="SearchRequest.MinSizeBytes" type="number" class="form-control" />
+            </div>
+            <div class="col-md-1">
+                <label asp-for="SearchRequest.MaxSizeBytes" class="form-label">Макс. размер</label>
+                <input asp-for="SearchRequest.MaxSizeBytes" type="number" class="form-control" />
+            </div>
+            <div class="col-md-1">
+                <button type="submit" class="btn btn-primary w-100">Найти</button>
+            </div>
+            <div class="col-md-1">
+                <a href="?folderId=@Model.CurrentFolderId" class="btn btn-secondary w-100">Сбросить</a>
+            </div>
+        </div>
+    </form>
 
     <!-- Content Area -->
     <div class="content-area">
+        @{
+            ViewData["SearchRequest"] = Model.SearchRequest;
+        }
         <div class="grid-view">
             @await Html.PartialAsync("_FilesGrid", Model.GridItems)
         </div>

--- a/FileManager.Web/Pages/Files/Index.cshtml.cs
+++ b/FileManager.Web/Pages/Files/Index.cshtml.cs
@@ -40,7 +40,7 @@ public class IndexModel : PageModel
         SearchRequest.FolderId = CurrentFolderId;
         Breadcrumbs = await _folderService.GetBreadcrumbsAsync(CurrentFolderId);
 
-        FilesResult = await _fileService.GetFilesAsync(SearchRequest, userId, isAdmin);
+        FilesResult = await _fileService.SearchFilesAsync(SearchRequest, userId, isAdmin);
         var folderContents = await _folderService.GetFolderContentsAsync(CurrentFolderId, userId, SearchRequest, isAdmin);
         if (folderContents != null)
         {

--- a/FileManager.Web/Pages/Files/_FilesGrid.cshtml
+++ b/FileManager.Web/Pages/Files/_FilesGrid.cshtml
@@ -1,15 +1,55 @@
 @model IEnumerable<FileManager.Application.DTOs.TreeNodeDto>
 @using System.Linq
+@using FileManager.Application.DTOs
+
+@{
+    var search = ViewData["SearchRequest"] as SearchRequestDto;
+}
 
 @if (Model.Any())
 {
     <div class="sort-controls">
         <span>Сортировка:</span>
-        <a href="javascript:void(0)" onclick="sortBy('name')" class="sort-link">По имени</a>
-        <a href="javascript:void(0)" onclick="sortBy('date')" class="sort-link">По дате</a>
-        <a href="javascript:void(0)" onclick="sortBy('size')" class="sort-link">По размеру</a>
-        <a href="javascript:void(0)" onclick="sortBy('type')" class="sort-link">По типу</a>
+        <a href="javascript:void(0)" onclick="sortBy('name')" class="sort-link @(search?.SortBy == "name" ? "active" : "")">
+            По имени@(search?.SortBy == "name" ? (search?.SortDirection == "asc" ? " ↑" : " ↓") : "")</a>
+        <a href="javascript:void(0)" onclick="sortBy('date')" class="sort-link @(search?.SortBy == "date" ? "active" : "")">
+            По дате@(search?.SortBy == "date" ? (search?.SortDirection == "asc" ? " ↑" : " ↓") : "")</a>
+        <a href="javascript:void(0)" onclick="sortBy('size')" class="sort-link @(search?.SortBy == "size" ? "active" : "")">
+            По размеру@(search?.SortBy == "size" ? (search?.SortDirection == "asc" ? " ↑" : " ↓") : "")</a>
+        <a href="javascript:void(0)" onclick="sortBy('type')" class="sort-link @(search?.SortBy == "type" ? "active" : "")">
+            По типу@(search?.SortBy == "type" ? (search?.SortDirection == "asc" ? " ↑" : " ↓") : "")</a>
     </div>
+
+    @if (search != null &&
+        (!string.IsNullOrEmpty(search.SearchTerm) || search.FileType.HasValue ||
+         search.DateFrom.HasValue || search.DateTo.HasValue ||
+         search.MinSizeBytes.HasValue || search.MaxSizeBytes.HasValue))
+    {
+        <div class="current-filter mb-2">
+            <span>Фильтр:</span>
+            <span>
+                @if (!string.IsNullOrEmpty(search.SearchTerm))
+                {
+                    <text>поиск "@search.SearchTerm"; </text>
+                }
+                @if (search.FileType.HasValue)
+                {
+                    <text>тип @search.FileType; </text>
+                }
+                @if (search.DateFrom.HasValue || search.DateTo.HasValue)
+                {
+                    <text>дата @search.DateFrom?.ToString("dd.MM.yyyy") - @search.DateTo?.ToString("dd.MM.yyyy"); </text>
+                }
+                @if (search.MinSizeBytes.HasValue || search.MaxSizeBytes.HasValue)
+                {
+                    var minSize = search.MinSizeBytes.HasValue ? FormatSize(search.MinSizeBytes.Value) : "0";
+                    var maxSize = search.MaxSizeBytes.HasValue ? FormatSize(search.MaxSizeBytes.Value) : "∞";
+                    <text>размер @minSize - @maxSize; </text>
+                }
+            </span>
+            <a href="?folderId=@ViewContext.HttpContext.Request.Query["folderId"]" class="btn btn-link btn-sm">Сбросить</a>
+        </div>
+    }
 
     <div class="files-grid">
     @foreach (var item in Model)


### PR DESCRIPTION
## Summary
- add search and filter panel for files including name, type, date, and size
- process query parameters and use SearchFilesAsync for filtering
- support advanced filters in FileService
- show active sort and current filter in grid

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689b04b64e848330909ae8b7350a080d