### PR TITLE
Handle missing favorites on remove

### DIFF
--- a/FileManager.Web/wwwroot/js/files-manager.js
+++ b/FileManager.Web/wwwroot/js/files-manager.js
@@ -425,16 +425,19 @@ class FilesManager {
 
     async removeFavorite(itemId, itemType) {
         try {
+            const el = document.querySelector(`[data-id="${itemId}"]`);
+            if (!el) {
+                return;
+            }
             const url = itemType === 'file'
                 ? `/api/favorites/files/${itemId}`
                 : `/api/favorites/folders/${itemId}`;
             const response = await fetch(url, { method: 'DELETE' });
             if (response.ok) {
                 this.showNotification('Удалено из избранного', 'success');
-                const el = document.querySelector(`[data-id="${itemId}"]`);
-                if (el) {
-                    el.remove();
-                }
+                el.remove();
+            } else if (response.status === 404) {
+                el.remove();
             } else {
                 const text = await response.text();
                 this.showNotification('Не удалось удалить из избранного: ' + text, 'error');


### PR DESCRIPTION
## Summary
- Check favorites item exists in DOM before requesting removal
- Treat 404 responses when removing favorite as success and drop DOM element

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689b22cc93a08330a67dbb020a5c7ccb