### PR TITLE
Исправить вызовы FilesManager на странице фотографий

### DIFF
--- a/FileManager.Web/Pages/Photos/Index.cshtml
+++ b/FileManager.Web/Pages/Photos/Index.cshtml
@@ -33,15 +33,11 @@
         window.filesManager = filesManager;
 
         function deletePhoto(id, name) {
-            if (window.deleteFile) {
-                deleteFile(id, name);
-            }
+            filesManager.deleteFile(id, name);
         }
 
         function showProperties(id, name) {
-            if (window.filesManager) {
-                filesManager.showProperties(id, name, 'file');
-            }
+            filesManager.showProperties(id, name, 'file');
         }
     </script>
 }

--- a/FileManager.Web/wwwroot/js/files-manager.js
+++ b/FileManager.Web/wwwroot/js/files-manager.js
@@ -482,7 +482,7 @@ class FilesManager {
 
         try {
             if (itemType === 'file') {
-                const res = await fetch(`/api/files/${itemId}`);
+                const res = await fetch(`/api/files/${itemId}`, { credentials: 'include' });
                 if (res.ok) {
                     const data = await res.json();
                     size = data.formattedSize;
@@ -491,7 +491,7 @@ class FilesManager {
                     updated = data.updatedAt ? new Date(data.updatedAt).toLocaleString() : created;
                 }
             } else {
-                const res = await fetch(`/api/folders/${itemId}`);
+                const res = await fetch(`/api/folders/${itemId}`, { credentials: 'include' });
                 if (res.ok) {
                     const data = await res.json();
                     creator = data.createdByName;
@@ -499,9 +499,12 @@ class FilesManager {
                     updated = data.updatedAt ? new Date(data.updatedAt).toLocaleString() : created;
                 }
             }
-            const accessRes = await fetch(itemType === 'file'
-                ? `/api/access/file/${itemId}`
-                : `/api/access/folder/${itemId}`);
+            const accessRes = await fetch(
+                itemType === 'file'
+                    ? `/api/access/file/${itemId}`
+                    : `/api/access/folder/${itemId}`,
+                { credentials: 'include' }
+            );
             if (accessRes.ok) {
                 accessRules = await accessRes.json();
             }


### PR DESCRIPTION
## Summary
- Удалены проверки `window.deleteFile` и `window.filesManager` на странице фотографий.
- В `files-manager.js` добавлено `credentials: 'include'` для запросов в методе отображения свойств.

## Testing
- `dotnet build FileManager.Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b24e688f48330890fcfa2802a09c1