### PR TITLE
Перенос селектора режима просмотра

### DIFF
--- a/FileManager.Web/Pages/Files/Index.cshtml
+++ b/FileManager.Web/Pages/Files/Index.cshtml
@@ -30,10 +30,20 @@
         </div>
     }
 
-    <div class="action-bar">
+    <div class="action-bar d-flex gap-2">
         <a asp-page="Upload" class="btn btn-primary btn-sm"><i class="bi bi-upload"></i> Загрузить файлы</a>
         <button type="button" id="btnCreateFolder" class="btn btn-primary btn-sm"><i class="bi bi-folder-plus"></i> Создать папку</button>
         <button type="button" id="btnManageAccess" class="btn btn-primary btn-sm"><i class="bi bi-shield-lock"></i> Управление доступом</button>
+        <div class="view-mode-selector dropdown ms-auto">
+            <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-grid"></i>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+                <li><a class="dropdown-item" href="#" data-view="large"><i class="bi bi-grid-3x3-gap"></i> Крупные</a></li>
+                <li><a class="dropdown-item" href="#" data-view="medium"><i class="bi bi-grid"></i> Средние</a></li>
+                <li><a class="dropdown-item" href="#" data-view="small"><i class="bi bi-list"></i> Мелкие</a></li>
+            </ul>
+        </div>
     </div>
 
     <!-- Панель поиска и фильтров -->
@@ -84,11 +94,6 @@
         @{
             ViewData["SearchRequest"] = Model.SearchRequest;
         }
-        <div class="view-mode-selector btn-group btn-group-sm mb-3" role="group">
-            <button type="button" class="btn btn-outline-secondary" data-view="large">Крупные</button>
-            <button type="button" class="btn btn-outline-secondary" data-view="medium">Средние</button>
-            <button type="button" class="btn btn-outline-secondary" data-view="small">Мелкие</button>
-        </div>
         <div class="grid-view">
             @await Html.PartialAsync("_FilesGrid", Model.GridItems)
         </div>

--- a/FileManager.Web/wwwroot/js/files-manager.js
+++ b/FileManager.Web/wwwroot/js/files-manager.js
@@ -45,9 +45,10 @@ class FilesManager {
         const saved = localStorage.getItem('filesViewMode') || 'medium';
         this.applyViewMode(saved);
         if (container) {
-            container.querySelectorAll('button').forEach(btn => {
-                btn.addEventListener('click', () => {
-                    const mode = btn.dataset.view;
+            container.querySelectorAll('[data-view]').forEach(el => {
+                el.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    const mode = el.dataset.view;
                     this.applyViewMode(mode);
                     localStorage.setItem('filesViewMode', mode);
                 });
@@ -62,9 +63,24 @@ class FilesManager {
         grid.classList.add(`view-${mode}`);
         const container = document.querySelector('.view-mode-selector');
         if (container) {
-            container.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-            const activeBtn = container.querySelector(`[data-view="${mode}"]`);
-            if (activeBtn) activeBtn.classList.add('active');
+            container.querySelectorAll('[data-view]').forEach(el => el.classList.remove('active'));
+            const activeEl = container.querySelector(`[data-view="${mode}"]`);
+            if (activeEl) activeEl.classList.add('active');
+            const icon = container.querySelector('.dropdown-toggle i');
+            if (icon) {
+                icon.className = this.getViewIconClass(mode);
+            }
+        }
+    }
+
+    getViewIconClass(mode) {
+        switch (mode) {
+            case 'large':
+                return 'bi bi-grid-3x3-gap';
+            case 'small':
+                return 'bi bi-list';
+            default:
+                return 'bi bi-grid';
         }
     }
 


### PR DESCRIPTION
## Summary
- перемещён селектор режима отображения файлов в панель действий и оформлен как выпадающее меню
- обновлена логика `initViewMode` и `applyViewMode` для работы с новым меню и иконками

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b28f66c8083309804b9ac18f2f6a1