### PR TITLE
Refactor navigation and modularize frontend scripts

### DIFF
--- a/FileManager.Web/Pages/Shared/_Layout.cshtml
+++ b/FileManager.Web/Pages/Shared/_Layout.cshtml
@@ -71,7 +71,9 @@
         </main>
     }
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/notifications.js" asp-append-version="true"></script>
     <script src="~/js/files-manager.js" asp-append-version="true"></script>
+    <script src="~/js/context-menu.js" asp-append-version="true"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
     <div id="notificationContainer" class="notification-container"></div>

--- a/FileManager.Web/Pages/Shared/_LoginLayout.cshtml
+++ b/FileManager.Web/Pages/Shared/_LoginLayout.cshtml
@@ -12,6 +12,7 @@
         @RenderBody()
     </main>
 
+    <script src="~/js/notifications.js" asp-append-version="true"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/FileManager.Web/wwwroot/js/context-menu.js
+++ b/FileManager.Web/wwwroot/js/context-menu.js
@@ -1,0 +1,124 @@
+window.contextMenu = (function () {
+    function init(filesManager) {
+        document.addEventListener('contextmenu', (e) => {
+            const within = e.target.closest('.files-wrapper');
+            if (!within) return;
+            e.preventDefault();
+            const menu = document.getElementById('contextMenu');
+            if (!menu) return;
+            const item = e.target.closest('.explorer-item');
+            if (item) {
+                filesManager.contextItem = {
+                    id: item.dataset.id,
+                    name: item.dataset.name,
+                    type: item.dataset.type
+                };
+                menu.querySelector('[data-action="upload"]').style.display = 'none';
+                menu.querySelector('[data-action="create-folder"]').style.display = 'none';
+                menu.querySelector('[data-action="manage-access"]').style.display = 'none';
+                menu.querySelector('[data-action="rename"]').style.display = filesManager.contextItem.type === 'folder' ? 'flex' : 'none';
+                menu.querySelector('[data-action="download"]').style.display = filesManager.contextItem.type === 'file' ? 'flex' : 'none';
+                menu.querySelector('[data-action="preview"]').style.display = filesManager.contextItem.type === 'file' ? 'flex' : 'none';
+                menu.querySelector('[data-action="edit"]').style.display = filesManager.contextItem.type === 'file' ? 'flex' : 'none';
+                menu.querySelector('[data-action="access"]').style.display = 'flex';
+                menu.querySelector('[data-action="add-favorite"]').style.display = 'flex';
+                menu.querySelector('[data-action="delete"]').style.display = 'flex';
+                menu.querySelector('[data-action="properties"]').style.display = 'flex';
+            } else {
+                filesManager.contextItem = null;
+                menu.querySelector('[data-action="upload"]').style.display = 'flex';
+                menu.querySelector('[data-action="create-folder"]').style.display = 'flex';
+                menu.querySelector('[data-action="manage-access"]').style.display = 'flex';
+                menu.querySelector('[data-action="rename"]').style.display = 'none';
+                menu.querySelector('[data-action="download"]').style.display = 'none';
+                menu.querySelector('[data-action="preview"]').style.display = 'none';
+                menu.querySelector('[data-action="edit"]').style.display = 'none';
+                menu.querySelector('[data-action="access"]').style.display = 'none';
+                menu.querySelector('[data-action="add-favorite"]').style.display = 'none';
+                menu.querySelector('[data-action="delete"]').style.display = 'none';
+                menu.querySelector('[data-action="properties"]').style.display = 'none';
+            }
+            menu.style.display = 'block';
+            menu.style.left = e.pageX + 'px';
+            menu.style.top = e.pageY + 'px';
+        });
+
+        document.addEventListener('click', hideContextMenu);
+
+        const menu = document.getElementById('contextMenu');
+        if (menu) {
+            menu.addEventListener('click', (e) => {
+                const action = e.target.dataset.action || e.target.closest('li')?.dataset.action;
+                if (action) {
+                    handleContextAction(action, filesManager);
+                }
+            });
+        }
+    }
+
+    function hideContextMenu() {
+        const menu = document.getElementById('contextMenu');
+        if (menu) menu.style.display = 'none';
+    }
+
+    function handleContextAction(action, filesManager) {
+        if (['upload', 'create-folder', 'manage-access'].includes(action)) {
+            switch (action) {
+                case 'upload':
+                    openUploadModal(filesManager.currentFolderId);
+                    break;
+                case 'create-folder':
+                    openCreateFolderModal(filesManager.currentFolderId);
+                    break;
+                case 'manage-access':
+                    openAccessModal(filesManager.currentFolderId, true);
+                    break;
+            }
+            hideContextMenu();
+            return;
+        }
+        if (!filesManager.contextItem) return;
+        const { id, name, type } = filesManager.contextItem;
+        switch (action) {
+            case 'preview':
+                if (type === 'file') {
+                    filesManager.previewFile(id);
+                }
+                break;
+            case 'edit':
+                if (type === 'file') {
+                    filesManager.editFile(id);
+                }
+                break;
+            case 'rename':
+                if (type === 'folder') {
+                    openRenameFolderModal(id, name);
+                }
+                break;
+            case 'download':
+                if (type === 'file') {
+                    filesManager.downloadFile(id);
+                }
+                break;
+            case 'access':
+                openAccessModal(id, type === 'folder');
+                break;
+            case 'add-favorite':
+                filesManager.addFavorite(id, type);
+                break;
+            case 'delete':
+                if (type === 'file') {
+                    filesManager.deleteFile(id, name);
+                } else {
+                    deleteFolder(id, name);
+                }
+                break;
+            case 'properties':
+                filesManager.showProperties(id, name, type);
+                break;
+        }
+        hideContextMenu();
+    }
+
+    return { init };
+})();

--- a/FileManager.Web/wwwroot/js/files-manager.js
+++ b/FileManager.Web/wwwroot/js/files-manager.js
@@ -11,20 +11,14 @@ class FilesManager {
     init() {
         this.bindEvents();
         this.bindSelectionEvents();
-        this.bindContextMenu();
         this.loadInitialData();
     }
 
     navigateTo(url) {
-        if (window.loadPage) {
-            window.loadPage(url);
-        } else {
-            window.location.href = url;
-        }
+        window.location.href = url;
     }
 
     bindEvents() {
-      
         document.addEventListener('dblclick', (e) => {
             const item = e.target.closest('.explorer-item');
             if (!item) return;
@@ -37,128 +31,6 @@ class FilesManager {
                 this.previewFile(id);
             }
         });
-    }
-
-
-    bindContextMenu() {
-        document.addEventListener('contextmenu', (e) => {
-            const within = e.target.closest('.files-wrapper');
-            if (!within) return;
-            e.preventDefault();
-            const menu = document.getElementById('contextMenu');
-            if (!menu) return;
-            const item = e.target.closest('.explorer-item');
-            if (item) {
-                this.contextItem = {
-                    id: item.dataset.id,
-                    name: item.dataset.name,
-                    type: item.dataset.type
-                };
-                menu.querySelector('[data-action="upload"]').style.display = 'none';
-                menu.querySelector('[data-action="create-folder"]').style.display = 'none';
-                menu.querySelector('[data-action="manage-access"]').style.display = 'none';
-                menu.querySelector('[data-action="rename"]').style.display = this.contextItem.type === 'folder' ? 'flex' : 'none';
-                menu.querySelector('[data-action="download"]').style.display = this.contextItem.type === 'file' ? 'flex' : 'none';
-                menu.querySelector('[data-action="preview"]').style.display = this.contextItem.type === 'file' ? 'flex' : 'none';
-                menu.querySelector('[data-action="edit"]').style.display = this.contextItem.type === 'file' ? 'flex' : 'none';
-                menu.querySelector('[data-action="access"]').style.display = 'flex';
-                menu.querySelector('[data-action="add-favorite"]').style.display = 'flex';
-                menu.querySelector('[data-action="delete"]').style.display = 'flex';
-                menu.querySelector('[data-action="properties"]').style.display = 'flex';
-            } else {
-                this.contextItem = null;
-                menu.querySelector('[data-action="upload"]').style.display = 'flex';
-                menu.querySelector('[data-action="create-folder"]').style.display = 'flex';
-                menu.querySelector('[data-action="manage-access"]').style.display = 'flex';
-                menu.querySelector('[data-action="rename"]').style.display = 'none';
-                menu.querySelector('[data-action="download"]').style.display = 'none';
-                menu.querySelector('[data-action="preview"]').style.display = 'none';
-                menu.querySelector('[data-action="edit"]').style.display = 'none';
-                menu.querySelector('[data-action="access"]').style.display = 'none';
-                menu.querySelector('[data-action="add-favorite"]').style.display = 'none';
-                menu.querySelector('[data-action="delete"]').style.display = 'none';
-                menu.querySelector('[data-action="properties"]').style.display = 'none';
-            }
-            menu.style.display = 'block';
-            menu.style.left = e.pageX + 'px';
-            menu.style.top = e.pageY + 'px';
-        });
-
-        document.addEventListener('click', () => this.hideContextMenu());
-
-        const menu = document.getElementById('contextMenu');
-        if (menu) {
-            menu.addEventListener('click', (e) => {
-                const action = e.target.dataset.action || e.target.closest('li')?.dataset.action;
-                if (action) {
-                    this.handleContextAction(action);
-                }
-            });
-        }
-    }
-
-    hideContextMenu() {
-        const menu = document.getElementById('contextMenu');
-        if (menu) menu.style.display = 'none';
-    }
-
-    handleContextAction(action) {
-        if (['upload', 'create-folder', 'manage-access'].includes(action)) {
-            switch (action) {
-                case 'upload':
-                    openUploadModal(this.currentFolderId);
-                    break;
-                case 'create-folder':
-                    openCreateFolderModal(this.currentFolderId);
-                    break;
-                case 'manage-access':
-                    openAccessModal(this.currentFolderId, true);
-                    break;
-            }
-            this.hideContextMenu();
-            return;
-        }
-        if (!this.contextItem) return;
-        const { id, name, type } = this.contextItem;
-        switch (action) {
-            case 'preview':
-                if (type === 'file') {
-                    this.previewFile(id);
-                }
-                break;
-            case 'edit':
-                if (type === 'file') {
-                    this.editFile(id);
-                }
-                break;
-            case 'rename':
-                if (type === 'folder') {
-                    openRenameFolderModal(id, name);
-                }
-                break;
-            case 'download':
-                if (type === 'file') {
-                    this.downloadFile(id);
-                }
-                break;
-            case 'access':
-                openAccessModal(id, type === 'folder');
-                break;
-            case 'add-favorite':
-                this.addFavorite(id, type);
-                break;
-            case 'delete':
-                if (type === 'file') {
-                    this.deleteFile(id, name);
-                } else {
-                    deleteFolder(id, name);
-                }
-                break;
-            case 'properties':
-                this.showProperties(id, name, type);
-                break;
-        }
-        this.hideContextMenu();
     }
 
     bindSelectionEvents() {
@@ -815,28 +687,14 @@ function closePropertiesModal() {
 }
 
 // Initialize when DOM is loaded
-function initializeFilesManager() {
-    if (typeof filesManager === 'undefined') {
-        window.filesManager = new FilesManager();
-        filesManager = window.filesManager;
-    }
-}
-
-document.addEventListener('DOMContentLoaded', initializeFilesManager);
-
-
 // Open upload page
 window.openUploadModal = function (folderId) {
     const url = folderId ? `/Files/Upload?folderId=${folderId}` : '/Files/Upload';
-    if (typeof loadPage === 'function') {
-        loadPage(url);
-    } else {
-        window.location.href = url;
-    }
+    window.location.href = url;
 };
 
 // Drag and drop for the main page
-document.addEventListener('DOMContentLoaded', function () {
+function initDragAndDrop() {
     const mainContent = document.querySelector('.content-area');
     if (mainContent) {
         mainContent.addEventListener('dragover', function (e) {
@@ -867,8 +725,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
     }
-});
-
+}
 
 // Version management functions
 window.viewVersions = function (fileId) {
@@ -879,15 +736,21 @@ window.viewVersions = function (fileId) {
     }
 };
 
-// Add version button to file actions where appropriate
-document.addEventListener('DOMContentLoaded', function () {
-    // Add version history links to file context menus if they exist
+function initVersionHistoryLinks() {
     const fileItems = document.querySelectorAll('.file-card, .files-table tr');
     fileItems.forEach(item => {
         const fileId = item.getAttribute('data-file-id');
         if (fileId) {
-            // Add context menu or additional actions as needed
-            // This can be expanded based on UI requirements
+            // Placeholder for future version history integrations
         }
     });
-});
+}
+
+function initializeFilesManager() {
+    if (typeof window.filesManager === 'undefined') {
+        window.filesManager = new FilesManager();
+        filesManager = window.filesManager;
+        initDragAndDrop();
+        initVersionHistoryLinks();
+    }
+}

--- a/FileManager.Web/wwwroot/js/notifications.js
+++ b/FileManager.Web/wwwroot/js/notifications.js
@@ -1,0 +1,11 @@
+window.showNotification = function (message, type = 'info') {
+    const container = document.getElementById('notificationContainer');
+    if (!container) {
+        return;
+    }
+    const notification = document.createElement('div');
+    notification.className = `notification notification-${type}`;
+    notification.textContent = message;
+    container.appendChild(notification);
+    setTimeout(() => notification.remove(), 5000);
+};

--- a/FileManager.Web/wwwroot/js/site.js
+++ b/FileManager.Web/wwwroot/js/site.js
@@ -18,7 +18,6 @@ window.fetch = (input, init = {}) => {
 };
 
 let mainContainer;
-let isLoading = false;
 
 function initializeLayout() {
     const uploadBtn = document.getElementById('btnUpload');
@@ -86,79 +85,11 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     initializeLayout();
-});
-
-window.loadPage = async function (url, addToHistory = true) {
-    if (isLoading) return;
-    isLoading = true;
-    console.log('loadPage', url);
-    try {
-        const response = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
-        if (!response.ok) {
-            window.location.href = url;
-            return;
-        }
-        const html = await response.text();
-        const doc = new DOMParser().parseFromString(html, 'text/html');
-        const newContent = doc.getElementById('pageContainer');
-        const current = document.getElementById('pageContainer');
-        if (newContent && current) {
-            const scripts = newContent.querySelectorAll('script');
-            current.innerHTML = newContent.innerHTML;
-            scripts.forEach(oldScript => {
-                const script = document.createElement('script');
-                if (oldScript.src) {
-                    script.src = oldScript.src;
-                } else {
-                    script.textContent = oldScript.textContent;
-                }
-                document.body.appendChild(script);
-                document.body.removeChild(script);
-            });
-            if (typeof initializeFilesManager === 'function') {
-                initializeFilesManager();
-            }
-            initializeLayout();
-            if (addToHistory) {
-                history.pushState(null, '', url);
-            }
-        } else {
-            window.location.href = url;
-        }
-    } catch (err) {
-        console.error('loadPage error', err);
-        window.location.href = url;
-    } finally {
-        isLoading = false;
+    if (typeof initializeFilesManager === 'function') {
+        initializeFilesManager();
     }
-};
-
-document.addEventListener('click', function (e) {
-    const link = e.target.closest('a');
-    if (!link) return;
-    const href = link.getAttribute('href');
-    if (!href || href.startsWith('#')) return;
-    if (link.getAttribute('target') === '_blank' || link.hasAttribute('download')) return;
-    if (link.origin !== window.location.origin) return;
-    const url = new URL(link.href, window.location.origin);
-    e.preventDefault();
-    const finalUrl = url.pathname + (url.searchParams.toString() ? '?' + url.searchParams.toString() : '');
-    loadPage(finalUrl);
-});
-
-window.addEventListener('popstate', () => {
-    loadPage(window.location.href, false);
-});
-
-window.showNotification = function (message, type = 'info') {
-    const container = document.getElementById('notificationContainer');
-    if (!container) {
-        return;
+    if (window.contextMenu && typeof window.contextMenu.init === 'function' && window.filesManager) {
+        window.contextMenu.init(window.filesManager);
     }
-    const notification = document.createElement('div');
-    notification.className = `notification notification-${type}`;
-    notification.textContent = message;
-    container.appendChild(notification);
-    setTimeout(() => notification.remove(), 5000);
-};
+});
 


### PR DESCRIPTION
## Summary
- remove custom loadPage logic and rely on standard navigation
- modularize file manager, context menu and notification scripts
- centralize DOMContentLoaded initialization and update layouts

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689b302f1b9883309a41d1ad6d1de2eb