### PR TITLE
Добавлены иконки для новых типов файлов

### DIFF
--- a/FileManager.Application/DTOs/FolderDto.cs
+++ b/FileManager.Application/DTOs/FolderDto.cs
@@ -71,6 +71,10 @@ public class TreeNodeDto
             ".xls" or ".xlsx" => "xlsx",
             ".ppt" or ".pptx" => "pptx",
             ".txt" or ".md" => "txt",
+            ".csv" => "csv",
+            ".json" => "json",
+            ".xml" => "xml",
+            ".html" or ".htm" => "html",
             _ => "file"
         };
     }

--- a/FileManager.Web/wwwroot/images/file-icons/csv.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/csv.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#6d4c41"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">CSV</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/html.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/html.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#ef5350"/>
+  <text x="12" y="16" font-size="8" text-anchor="middle" fill="#fff">HTML</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/json.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/json.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#66bb6a"/>
+  <text x="12" y="16" font-size="8" text-anchor="middle" fill="#fff">JSON</text>
+</svg>

--- a/FileManager.Web/wwwroot/images/file-icons/xml.svg
+++ b/FileManager.Web/wwwroot/images/file-icons/xml.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#ab47bc"/>
+  <text x="12" y="16" font-size="10" text-anchor="middle" fill="#fff">XML</text>
+</svg>


### PR DESCRIPTION
## Summary
- расширена логика выбора иконок для файлов CSV, JSON, XML и HTML
- добавлены соответствующие SVG‑файлы в каталог `wwwroot/images/file-icons`

## Testing
- `dotnet build FileManager.Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b34e5ce30833091d5059f51417ed2