### PR TITLE
Allow owner full access to own folders and files

### DIFF
--- a/FileManager.Application/Services/AccessService.cs
+++ b/FileManager.Application/Services/AccessService.cs
@@ -161,6 +161,9 @@ public class AccessService : IAccessService
         if (file == null)
             return AccessType.None;
 
+        if (file.UploadedById == userId)
+            return AccessType.FullAccess;
+
         var access = await GetDirectAccessAsync(userId, userGroups, fileId, null, false);
         if (access != AccessType.None)
             return access;
@@ -185,6 +188,9 @@ public class AccessService : IAccessService
             .FirstOrDefaultAsync(f => f.Id == folderId);
         if (folder == null)
             return AccessType.None;
+
+        if (folder.CreatedById == userId)
+            return AccessType.FullAccess;
 
         var access = await GetDirectAccessAsync(userId, userGroups, null, folderId, inheritedOnly);
         if (access != AccessType.None)

--- a/FileManager.Infrastructure/Repositories/FolderRepository.cs
+++ b/FileManager.Infrastructure/Repositories/FolderRepository.cs
@@ -139,7 +139,7 @@ public class FolderRepository : IFolderRepository
 
         return await _context.Folders
             .Where(f => f.ParentFolderId == null && !f.IsDeleted)
-            .Where(f => f.AccessRules.Any(r =>
+            .Where(f => f.CreatedById == userId || f.AccessRules.Any(r =>
                 r.FolderId == f.Id &&
                 (r.UserId == userId || (r.GroupId.HasValue && userGroupIds.Contains(r.GroupId.Value))) &&
                 (r.AccessType & Domain.Enums.AccessType.Read) == Domain.Enums.AccessType.Read))


### PR DESCRIPTION
## Summary
- include owner-created root folders in user accessible list
- grant full access to file or folder when user is the uploader/creator

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c201420d88330986cf64f5bbb0b8b