### PR TITLE
Исключение владельца из выдачи доступа

### DIFF
--- a/FileManager.Web/Controllers/UsersApiController.cs
+++ b/FileManager.Web/Controllers/UsersApiController.cs
@@ -1,6 +1,7 @@
 using FileManager.Application.DTOs;
 using FileManager.Application.Interfaces;
 using FileManager.Application.Services;
+using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,9 +22,13 @@ public class UsersApiController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<List<UserDto>>> GetAll()
+    public async Task<ActionResult<List<UserDto>>> GetAll([FromQuery] Guid? ownerId)
     {
         var users = await _userDtoService.GetAllUsersAsync();
+        if (ownerId.HasValue)
+        {
+            users = users.Where(u => u.Id != ownerId.Value).ToList();
+        }
         return Ok(users);
     }
 

--- a/FileManager.Web/Pages/Files/_AccessModal.cshtml
+++ b/FileManager.Web/Pages/Files/_AccessModal.cshtml
@@ -61,7 +61,7 @@
         }
 
         const [usersRes, groupsRes] = await Promise.all([
-            fetch('/api/users', { credentials: 'include' }),
+            fetch(`/api/users${ownerId ? `?ownerId=${ownerId}` : ''}`, { credentials: 'include' }),
             fetch('/api/groups', { credentials: 'include' })
         ]);
         const users = usersRes.ok ? await usersRes.json() : [];


### PR DESCRIPTION
## Summary
- Не передаем владельца в списке пользователей и запрашиваем сервер с параметром ownerId
- На сервере UsersApiController фильтрует владельца из общего списка

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c264ea0ac8330b323c0a57fdb23c3