### PR TITLE
Заменен прогресс-бар загрузчика на спиннер

### DIFF
--- a/FileManager.Web/Pages/Files/Upload.cshtml
+++ b/FileManager.Web/Pages/Files/Upload.cshtml
@@ -272,6 +272,7 @@
         const folderId = document.getElementById('uploadFolderSelect').value;
         const comment = document.getElementById('uploadComment').value;
 
+        showLoader();
         document.getElementById('uploadProgress').style.display = 'block';
         document.getElementById('uploadBtn').disabled = true;
 
@@ -280,14 +281,18 @@
 
         async function uploadNext(index) {
             if (index >= totalFiles) {
+                hideLoader();
                 showUploadResults(results);
                 return;
             }
 
             if (!await refreshCsrfToken()) {
+                hideLoader();
                 showUploadError('Не удалось обновить токен безопасности. Пожалуйста, перезагрузите страницу.');
                 return;
             }
+
+            showLoader();
 
             const file = selectedFiles[index];
             const formData = new FormData();
@@ -373,6 +378,7 @@
             };
 
             xhr.ontimeout = function () {
+                hideLoader();
                 showUploadError('Время ожидания истекло, попробуйте ещё раз');
             };
 

--- a/FileManager.Web/Pages/Files/_UploadModal.cshtml
+++ b/FileManager.Web/Pages/Files/_UploadModal.cshtml
@@ -317,6 +317,7 @@
         const folderId = document.getElementById('uploadFolderSelect').value;
         const comment = document.getElementById('uploadComment').value;
 
+        showLoader();
         document.getElementById('uploadProgress').style.display = 'block';
         document.getElementById('uploadBtn').disabled = true;
 
@@ -325,14 +326,18 @@
 
         async function uploadNext(index) {
             if (index >= totalFiles) {
+                hideLoader();
                 showUploadResults(results);
                 return;
             }
 
             if (!await refreshCsrfToken()) {
+                hideLoader();
                 showUploadError('Не удалось обновить токен безопасности. Пожалуйста, перезагрузите страницу.');
                 return;
             }
+
+            showLoader();
 
             const file = selectedFiles[index];
             const formData = new FormData();
@@ -418,6 +423,7 @@
             };
 
             xhr.ontimeout = function () {
+                hideLoader();
                 showUploadError('Время ожидания истекло, попробуйте ещё раз');
             };
 

--- a/FileManager.Web/Pages/Shared/_Layout.cshtml
+++ b/FileManager.Web/Pages/Shared/_Layout.cshtml
@@ -85,9 +85,7 @@
     }
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <div id="loader">
-        <div class="progress w-50">
-            <div id="loader-bar" class="progress-bar" role="progressbar" style="width:0%">0%</div>
-        </div>
+        <div class="spinner-border text-light" role="status"></div>
     </div>
     <script src="~/js/loader.js" asp-append-version="true"></script>
     <script src="~/js/notifications.js" asp-append-version="true"></script>

--- a/FileManager.Web/wwwroot/js/loader.js
+++ b/FileManager.Web/wwwroot/js/loader.js
@@ -1,50 +1,22 @@
-(function(){
+(function () {
     const loader = document.getElementById('loader');
-    const bar = document.getElementById('loader-bar');
-    function update(percent){
-        if(bar){
-            bar.style.width = percent + '%';
-            bar.textContent = percent + '%';
-        }
-    }
-    window.showLoader = function(percent){
-        if(loader){
+
+    window.showLoader = function () {
+        if (loader) {
             loader.style.display = 'flex';
-            update(percent);
         }
     };
-    window.hideLoader = function(){
-        if(loader){
+
+    window.hideLoader = function () {
+        if (loader) {
             loader.style.display = 'none';
         }
     };
-    window.fetchWithProgress = async function(url, options){
-        showLoader(0);
+
+    window.fetchWithProgress = async function (url, options) {
+        showLoader();
         try {
-            const response = await fetch(url, options);
-            const contentLength = response.headers.get('Content-Length');
-            if(!response.body || !contentLength){
-                update(100);
-                return response;
-            }
-            const total = parseInt(contentLength,10);
-            let loaded = 0;
-            const reader = response.body.getReader();
-            const chunks = [];
-            while(true){
-                const {done, value} = await reader.read();
-                if(done) break;
-                chunks.push(value);
-                loaded += value.length;
-                update(Math.round((loaded/total)*100));
-            }
-            update(100);
-            const blob = new Blob(chunks);
-            return new Response(blob, {
-                status: response.status,
-                statusText: response.statusText,
-                headers: response.headers
-            });
+            return await fetch(url, options);
         } finally {
             hideLoader();
         }


### PR DESCRIPTION
## Summary
- заменена разметка прогресс-бара на спиннер Bootstrap в макете
- упрощён loader.js: только показ/скрытие спиннера и обёртка fetchWithProgress
- добавлены showLoader/hideLoader в загрузке файлов, чтобы спиннер отображался до окончания операций

## Testing
- `dotnet build FileManager.Web.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c3cd442d08330ace338d22089c2f8