### PR TITLE
Handle context menu viewport bounds and resize

### DIFF
--- a/FileManager.Web/wwwroot/js/context-menu.js
+++ b/FileManager.Web/wwwroot/js/context-menu.js
@@ -39,11 +39,27 @@ window.contextMenu = (function () {
                 menu.querySelector('[data-action="properties"]').style.display = 'none';
             }
             menu.style.display = 'block';
-            menu.style.left = e.pageX + 'px';
-            menu.style.top = e.pageY + 'px';
+            let left = e.pageX;
+            let top = e.pageY;
+
+            const menuWidth = menu.offsetWidth;
+            const menuHeight = menu.offsetHeight;
+            const viewportWidth = window.innerWidth;
+            const viewportHeight = window.innerHeight;
+
+            if (left + menuWidth > viewportWidth) {
+                left = viewportWidth - menuWidth;
+            }
+            if (top + menuHeight > viewportHeight) {
+                top = viewportHeight - menuHeight;
+            }
+
+            menu.style.left = Math.max(0, left) + 'px';
+            menu.style.top = Math.max(0, top) + 'px';
         });
 
         document.addEventListener('click', hideContextMenu);
+        window.addEventListener('resize', hideContextMenu);
 
         const menu = document.getElementById('contextMenu');
         if (menu) {


### PR DESCRIPTION
## Summary
- keep context menu within viewport bounds
- hide context menu on window resize

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_689dd40d0d508330af32ac43d0216ce9